### PR TITLE
Fix go.mod go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module seanime
 
-go 1.23
+go 1.23.0
 
 require (
 	fyne.io/systray v1.11.0


### PR DESCRIPTION
Previosuly:
```
$ go build -o seanime -trimpath -ldflags="-s -w"
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
```
After this PR it compiles.

This is probably due to the fact that `golang` started downloading toolchains automatically from go 1.21 and https://github.com/golang/go/issues/57631 so `go 1.23` is not valid