### PR TITLE
Hide vertical reader scrollbar on mobile

### DIFF
--- a/seanime-web/src/app/(main)/manga/_containers/chapter-reader/_components/chapter-vertical-reader.tsx
+++ b/seanime-web/src/app/(main)/manga/_containers/chapter-reader/_components/chapter-vertical-reader.tsx
@@ -175,6 +175,7 @@ export function MangaVerticalReader({ pageContainer }: MangaVerticalReaderProps)
                     "w-full h-[calc(100dvh-3rem)] overflow-y-auto overflow-x-hidden px-4 select-none relative focus-visible:outline-none",
                     hiddenBar && "h-dvh",
                     pageGap && "space-y-4",
+                    isMobile() && "hide-scrollbar",
                 )}
                 ref={containerRef}
                 tabIndex={-1}

--- a/seanime-web/src/app/globals.css
+++ b/seanime-web/src/app/globals.css
@@ -299,3 +299,14 @@ pre {
     left: 0;
     transform: translateZ(0);
 }
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.hide-scrollbar::-webkit-scrollbar {
+    display: none;
+}
+  
+/* Hide scrollbar for IE, Edge and Firefox */
+.hide-scrollbar {
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+}


### PR DESCRIPTION
Hide's scrollbar on mobile for manga's vertical reader.
As a side effect this also centers the images, as they were off-center previously. (Most likely not the best workaround for this specific issue as they will still be off-center on desktop)