### PR TITLE
feat(discord): show media title as status setting

### DIFF
--- a/internal/database/models/models.go
+++ b/internal/database/models/models.go
@@ -158,7 +158,7 @@ type DiscordSettings struct {
 	RichPresenceHideSeanimeRepositoryButton bool `gorm:"column:rich_presence_hide_seanime_repository_button" json:"richPresenceHideSeanimeRepositoryButton"`
 	RichPresenceShowAniListMediaButton      bool `gorm:"column:rich_presence_show_anilist_media_button" json:"richPresenceShowAniListMediaButton"`
 	RichPresenceShowAniListProfileButton    bool `gorm:"column:rich_presence_show_anilist_profile_button" json:"richPresenceShowAniListProfileButton"`
-	RichPresenceStatusTitle                 bool `gorm:"column:rich_presence_status_title" json:"richPresenceStatusTitle"`
+	RichPresenceUseMediaTitleStatus         bool `gorm:"column:rich_presence_use_media_title_status" json:"richPresenceUseMediaTitleStatus"`
 }
 
 type NotificationSettings struct {

--- a/internal/database/models/models.go
+++ b/internal/database/models/models.go
@@ -158,6 +158,7 @@ type DiscordSettings struct {
 	RichPresenceHideSeanimeRepositoryButton bool `gorm:"column:rich_presence_hide_seanime_repository_button" json:"richPresenceHideSeanimeRepositoryButton"`
 	RichPresenceShowAniListMediaButton      bool `gorm:"column:rich_presence_show_anilist_media_button" json:"richPresenceShowAniListMediaButton"`
 	RichPresenceShowAniListProfileButton    bool `gorm:"column:rich_presence_show_anilist_profile_button" json:"richPresenceShowAniListProfileButton"`
+	RichPresenceStatusTitle                 bool `gorm:"column:rich_presence_status_title" json:"richPresenceStatusTitle"`
 }
 
 type NotificationSettings struct {

--- a/internal/discordrpc/client/activity.go
+++ b/internal/discordrpc/client/activity.go
@@ -12,6 +12,7 @@ import (
 //
 // See https://discord.com/developers/docs/game-sdk/activities#data-models-activity-struct
 type Activity struct {
+	Name    string `json:"name,omitempty"`
 	Details string `json:"details,omitempty"`
 	State   string `json:"state,omitempty"`
 

--- a/internal/discordrpc/presence/hook_events.go
+++ b/internal/discordrpc/presence/hook_events.go
@@ -1,7 +1,7 @@
 package discordrpc_presence
 
 import (
-	"seanime/internal/discordrpc/client"
+	discordrpc_client "seanime/internal/discordrpc/client"
 	"seanime/internal/hook_resolver"
 )
 
@@ -14,6 +14,8 @@ type DiscordPresenceAnimeActivityRequestedEvent struct {
 	// Anime activity object used to generate the activity
 	AnimeActivity *AnimeActivity `json:"animeActivity"`
 
+	// Name of the activity
+	Name string `json:"name"`
 	// Details of the activity
 	Details string `json:"details"`
 	// State of the activity
@@ -47,6 +49,8 @@ type DiscordPresenceMangaActivityRequestedEvent struct {
 	// Manga activity object used to generate the activity
 	MangaActivity *MangaActivity `json:"mangaActivity"`
 
+	// Name of the activity
+	Name string `json:"name"`
 	// Details of the activity
 	Details string `json:"details"`
 	// State of the activity

--- a/internal/discordrpc/presence/presence.go
+++ b/internal/discordrpc/presence/presence.go
@@ -298,7 +298,7 @@ func (p *Presence) SetAnimeActivity(a *AnimeActivity) {
 	activity.Assets.LargeText = a.Title
 
 	// Set status using the Anime title
-	if p.settings.RichPresenceStatusTitle {
+	if p.settings.RichPresenceUseMediaTitleStatus {
 		activity.Name = a.Title
 	}
 
@@ -565,12 +565,11 @@ func (p *Presence) SetMangaActivity(a *MangaActivity) {
 	activity.State = fmt.Sprintf("Reading Chapter %s", a.Chapter)
 	activity.Assets.LargeImage = a.Image
 	activity.Assets.LargeText = a.Title
-	activity.Type = 0 // Force playing activity for manga
 
 	// Set status using the Manga title
-	//if p.settings.RichPresenceStatusTitle {
-	//	activity.Name = a.Title
-	//}
+	if p.settings.RichPresenceUseMediaTitleStatus {
+		activity.Name = a.Title
+	}
 
 	now := time.Now()
 	activity.Timestamps.Start.Time = now

--- a/internal/discordrpc/presence/presence.go
+++ b/internal/discordrpc/presence/presence.go
@@ -222,6 +222,7 @@ func (p *Presence) check() (proceed bool) {
 
 var (
 	defaultActivity = discordrpc_client.Activity{
+		Name:    "Seanime",
 		Details: "",
 		State:   "",
 		Assets: &discordrpc_client.Assets{
@@ -296,6 +297,11 @@ func (p *Presence) SetAnimeActivity(a *AnimeActivity) {
 	activity.Assets.LargeImage = a.Image
 	activity.Assets.LargeText = a.Title
 
+	// Set status using the Anime title
+	if p.settings.RichPresenceStatusTitle {
+		activity.Name = a.Title
+	}
+
 	// Calculate the start time
 	startTime := time.Now()
 	if a.Progress > 0 {
@@ -344,6 +350,7 @@ func (p *Presence) SetAnimeActivity(a *AnimeActivity) {
 	p.animeActivity = a
 
 	event.AnimeActivity = a
+	event.Name = activity.Name
 	event.Details = a.Title
 	event.State = state
 	event.LargeImage = a.Image
@@ -361,6 +368,7 @@ func (p *Presence) SetAnimeActivity(a *AnimeActivity) {
 	}
 
 	// Update the activity
+	activity.Name = event.Name
 	activity.Details = event.Details
 	activity.State = event.State
 	activity.Assets.LargeImage = event.LargeImage
@@ -557,6 +565,13 @@ func (p *Presence) SetMangaActivity(a *MangaActivity) {
 	activity.State = fmt.Sprintf("Reading Chapter %s", a.Chapter)
 	activity.Assets.LargeImage = a.Image
 	activity.Assets.LargeText = a.Title
+	activity.Type = 0 // Force playing activity for manga
+
+	// Set status using the Manga title
+	//if p.settings.RichPresenceStatusTitle {
+	//	activity.Name = a.Title
+	//}
+
 	now := time.Now()
 	activity.Timestamps.Start.Time = now
 	event.StartTimestamp = lo.ToPtr(now.Unix())
@@ -586,6 +601,7 @@ func (p *Presence) SetMangaActivity(a *MangaActivity) {
 	}
 
 	event.MangaActivity = a
+	event.Name = activity.Name
 	event.Details = a.Title
 	event.State = activity.State
 	event.LargeImage = activity.Assets.LargeImage
@@ -603,6 +619,7 @@ func (p *Presence) SetMangaActivity(a *MangaActivity) {
 	}
 
 	// Update the activity
+	activity.Name = event.Name
 	activity.Details = event.Details
 	activity.State = event.State
 	activity.Assets.LargeImage = event.LargeImage

--- a/seanime-web/src/api/generated/types.ts
+++ b/seanime-web/src/api/generated/types.ts
@@ -2934,7 +2934,7 @@ export type Models_DiscordSettings = {
     richPresenceHideSeanimeRepositoryButton: boolean
     richPresenceShowAniListMediaButton: boolean
     richPresenceShowAniListProfileButton: boolean
-    richPresenceStatusTitle: boolean
+    richPresenceUseMediaTitleStatus: boolean
 }
 
 /**

--- a/seanime-web/src/api/generated/types.ts
+++ b/seanime-web/src/api/generated/types.ts
@@ -2934,6 +2934,7 @@ export type Models_DiscordSettings = {
     richPresenceHideSeanimeRepositoryButton: boolean
     richPresenceShowAniListMediaButton: boolean
     richPresenceShowAniListProfileButton: boolean
+    richPresenceStatusTitle: boolean
 }
 
 /**

--- a/seanime-web/src/app/(main)/_features/getting-started/getting-started-page.tsx
+++ b/seanime-web/src/app/(main)/_features/getting-started/getting-started-page.tsx
@@ -112,6 +112,7 @@ export function GettingStartedPage({ status }: { status: Status }) {
                                         richPresenceHideSeanimeRepositoryButton: false,
                                         richPresenceShowAniListMediaButton: false,
                                         richPresenceShowAniListProfileButton: false,
+                                        richPresenceStatusTitle: false,
                                     },
                                     torrent: {
                                         defaultTorrentClient: data.defaultTorrentClient,

--- a/seanime-web/src/app/(main)/_features/getting-started/getting-started-page.tsx
+++ b/seanime-web/src/app/(main)/_features/getting-started/getting-started-page.tsx
@@ -112,7 +112,7 @@ export function GettingStartedPage({ status }: { status: Status }) {
                                         richPresenceHideSeanimeRepositoryButton: false,
                                         richPresenceShowAniListMediaButton: false,
                                         richPresenceShowAniListProfileButton: false,
-                                        richPresenceStatusTitle: false,
+                                        richPresenceUseMediaTitleStatus: false,
                                     },
                                     torrent: {
                                         defaultTorrentClient: data.defaultTorrentClient,

--- a/seanime-web/src/app/(main)/settings/_containers/discord-rich-presence-settings.tsx
+++ b/seanime-web/src/app/(main)/settings/_containers/discord-rich-presence-settings.tsx
@@ -67,9 +67,9 @@ export function DiscordRichPresenceSettings(props: DiscordRichPresenceSettingsPr
 
                 <Field.Switch
                     side="right"
-                    name="richPresenceStatusTitle"
-                    label="Use Anime Title For Status"
-                    help="Use anime title for status instead of Seanime."
+                    name="richPresenceUseMediaTitleStatus"
+                    label="Use Media Title Status"
+                    help="Replace 'Seanime' with the media title for the status"
                 />
             </SettingsCard>
         </>

--- a/seanime-web/src/app/(main)/settings/_containers/discord-rich-presence-settings.tsx
+++ b/seanime-web/src/app/(main)/settings/_containers/discord-rich-presence-settings.tsx
@@ -64,6 +64,13 @@ export function DiscordRichPresenceSettings(props: DiscordRichPresenceSettingsPr
                     label="Show AniList Profile Button"
                     help="Show a button to open your profile page on AniList."
                 />
+
+                <Field.Switch
+                    side="right"
+                    name="richPresenceStatusTitle"
+                    label="Use Anime Title For Status"
+                    help="Use anime title for status instead of Seanime."
+                />
             </SettingsCard>
         </>
     )

--- a/seanime-web/src/app/(main)/settings/page.tsx
+++ b/seanime-web/src/app/(main)/settings/page.tsx
@@ -228,6 +228,7 @@ export default function Page() {
                                         richPresenceHideSeanimeRepositoryButton: data?.richPresenceHideSeanimeRepositoryButton ?? false,
                                         richPresenceShowAniListMediaButton: data?.richPresenceShowAniListMediaButton ?? false,
                                         richPresenceShowAniListProfileButton: data?.richPresenceShowAniListProfileButton ?? false,
+                                        richPresenceStatusTitle: data?.richPresenceStatusTitle ?? false,
                                     },
                                     anilist: {
                                         hideAudienceScore: data.hideAudienceScore,
@@ -292,6 +293,7 @@ export default function Page() {
                                 richPresenceHideSeanimeRepositoryButton: status?.settings?.discord?.richPresenceHideSeanimeRepositoryButton ?? false,
                                 richPresenceShowAniListMediaButton: status?.settings?.discord?.richPresenceShowAniListMediaButton ?? false,
                                 richPresenceShowAniListProfileButton: status?.settings?.discord?.richPresenceShowAniListProfileButton ?? false,
+                                richPresenceStatusTitle: status?.settings?.discord?.richPresenceStatusTitle ?? false,
                                 disableNotifications: status?.settings?.notifications?.disableNotifications ?? false,
                                 disableAutoDownloaderNotifications: status?.settings?.notifications?.disableAutoDownloaderNotifications ?? false,
                                 disableAutoScannerNotifications: status?.settings?.notifications?.disableAutoScannerNotifications ?? false,

--- a/seanime-web/src/app/(main)/settings/page.tsx
+++ b/seanime-web/src/app/(main)/settings/page.tsx
@@ -228,7 +228,7 @@ export default function Page() {
                                         richPresenceHideSeanimeRepositoryButton: data?.richPresenceHideSeanimeRepositoryButton ?? false,
                                         richPresenceShowAniListMediaButton: data?.richPresenceShowAniListMediaButton ?? false,
                                         richPresenceShowAniListProfileButton: data?.richPresenceShowAniListProfileButton ?? false,
-                                        richPresenceStatusTitle: data?.richPresenceStatusTitle ?? false,
+                                        richPresenceUseMediaTitleStatus: data?.richPresenceUseMediaTitleStatus ?? false,
                                     },
                                     anilist: {
                                         hideAudienceScore: data.hideAudienceScore,
@@ -293,7 +293,7 @@ export default function Page() {
                                 richPresenceHideSeanimeRepositoryButton: status?.settings?.discord?.richPresenceHideSeanimeRepositoryButton ?? false,
                                 richPresenceShowAniListMediaButton: status?.settings?.discord?.richPresenceShowAniListMediaButton ?? false,
                                 richPresenceShowAniListProfileButton: status?.settings?.discord?.richPresenceShowAniListProfileButton ?? false,
-                                richPresenceStatusTitle: status?.settings?.discord?.richPresenceStatusTitle ?? false,
+                                richPresenceUseMediaTitleStatus: status?.settings?.discord?.richPresenceUseMediaTitleStatus ?? false,
                                 disableNotifications: status?.settings?.notifications?.disableNotifications ?? false,
                                 disableAutoDownloaderNotifications: status?.settings?.notifications?.disableAutoDownloaderNotifications ?? false,
                                 disableAutoScannerNotifications: status?.settings?.notifications?.disableAutoScannerNotifications ?? false,

--- a/seanime-web/src/lib/server/settings.ts
+++ b/seanime-web/src/lib/server/settings.ts
@@ -73,6 +73,7 @@ export const settingsSchema = z.object({
     richPresenceHideSeanimeRepositoryButton: z.boolean().optional().default(false),
     richPresenceShowAniListMediaButton: z.boolean().optional().default(false),
     richPresenceShowAniListProfileButton: z.boolean().optional().default(false),
+    richPresenceStatusTitle: z.boolean().optional().default(false),
     disableNotifications: z.boolean().optional().default(false),
     disableAutoDownloaderNotifications: z.boolean().optional().default(false),
     disableAutoScannerNotifications: z.boolean().optional().default(false),

--- a/seanime-web/src/lib/server/settings.ts
+++ b/seanime-web/src/lib/server/settings.ts
@@ -73,7 +73,7 @@ export const settingsSchema = z.object({
     richPresenceHideSeanimeRepositoryButton: z.boolean().optional().default(false),
     richPresenceShowAniListMediaButton: z.boolean().optional().default(false),
     richPresenceShowAniListProfileButton: z.boolean().optional().default(false),
-    richPresenceStatusTitle: z.boolean().optional().default(false),
+    richPresenceUseMediaTitleStatus: z.boolean().optional().default(false),
     disableNotifications: z.boolean().optional().default(false),
     disableAutoDownloaderNotifications: z.boolean().optional().default(false),
     disableAutoScannerNotifications: z.boolean().optional().default(false),


### PR DESCRIPTION
Introduce a new setting that allows users to customize their Discord presence by displaying the currently watched anime title, replacing the default `Watching Seanime` with `Watching <Anime Title>`

The setting is opt-in, disabled by default and applies only to anime.

For manga, the presence will now be forced to `Playing Seanime` for clarity and consistency.