### PR TITLE
Add auto fullscreen on next episode for Desktop

### DIFF
--- a/seanime-web/src/app/(main)/_features/sea-media-player/sea-media-player-components.tsx
+++ b/seanime-web/src/app/(main)/_features/sea-media-player/sea-media-player-components.tsx
@@ -9,6 +9,7 @@ import { RxSlider } from "react-icons/rx"
 import {
     __seaMediaPlayer_autoNextAtom,
     __seaMediaPlayer_autoPlayAtom,
+    __seaMediaPlayer_autoFullscreenNextAtom,
     __seaMediaPlayer_autoSkipIntroOutroAtom,
     __seaMediaPlayer_discreteControlsAtom,
 } from "./sea-media-player.atoms"
@@ -17,8 +18,10 @@ export function SeaMediaPlayerPlaybackSubmenu() {
 
     const [autoPlay, setAutoPlay] = useAtom(__seaMediaPlayer_autoPlayAtom)
     const [autoNext, setAutoNext] = useAtom(__seaMediaPlayer_autoNextAtom)
+    const [autoFullscreenNext, setAutoFullscreenNext] = useAtom(__seaMediaPlayer_autoFullscreenNextAtom)
     const [autoSkipIntroOutro, setAutoSkipIntroOutro] = useAtom(__seaMediaPlayer_autoSkipIntroOutroAtom)
     const [discreteControls, setDiscreteControls] = useAtom(__seaMediaPlayer_discreteControlsAtom)
+    const isDesktop = process.env.NEXT_PUBLIC_PLATFORM === "desktop"
 
     return (
         <>
@@ -54,6 +57,24 @@ export function SeaMediaPlayerPlaybackSubmenu() {
                     />
                 </Menu.Content>
             </Menu.Root>
+            {isDesktop && (
+            <Menu.Root>
+                <VdsSubmenuButton
+                    label={`Auto Fullscreen Next Episode`}
+                    hint={autoFullscreenNext ? "On" : "Off"}
+                    disabled={false}
+                    icon={MdPlaylistPlay}
+                />
+                <Menu.Content className={submenuClass}>
+                    <Switch
+                        label="Auto Fullscreen next Episode"
+                        fieldClass="py-2 px-2"
+                        value={autoFullscreenNext}
+                        onValueChange={setAutoFullscreenNext}
+                    />
+                </Menu.Content>
+            </Menu.Root>
+            )}
             <Menu.Root>
                 <VdsSubmenuButton
                     label={`Skip Intro/Outro`}

--- a/seanime-web/src/app/(main)/_features/sea-media-player/sea-media-player.atoms.ts
+++ b/seanime-web/src/app/(main)/_features/sea-media-player/sea-media-player.atoms.ts
@@ -4,6 +4,8 @@ export const __seaMediaPlayer_autoPlayAtom = atomWithStorage("sea-media-player-a
 
 export const __seaMediaPlayer_autoNextAtom = atomWithStorage("sea-media-player-autonext", false)
 
+export const __seaMediaPlayer_autoFullscreenNextAtom = atomWithStorage("sea-media-player-autofullscreen-next", false)
+
 export const __seaMediaPlayer_autoSkipIntroOutroAtom = atomWithStorage("sea-media-player-autoskip-intro-outro", false)
 
 export const __seaMediaPlayer_discreteControlsAtom = atomWithStorage("sea-media-player-discrete-controls", false)

--- a/seanime-web/src/app/(main)/_features/sea-media-player/sea-media-player.tsx
+++ b/seanime-web/src/app/(main)/_features/sea-media-player/sea-media-player.tsx
@@ -16,6 +16,7 @@ import {
     useSeaMediaPlayer,
 } from "@/app/(main)/_features/sea-media-player/sea-media-player-provider"
 import {
+    __seaMediaPlayer_autoFullscreenNextAtom,
     __seaMediaPlayer_autoNextAtom,
     __seaMediaPlayer_autoPlayAtom,
     __seaMediaPlayer_autoSkipIntroOutroAtom,
@@ -125,6 +126,7 @@ export function SeaMediaPlayer(props: SeaMediaPlayerProps) {
 
     const autoPlay = useAtomValue(__seaMediaPlayer_autoPlayAtom)
     const autoNext = useAtomValue(__seaMediaPlayer_autoNextAtom)
+    const autoFullscreenNext = useAtomValue(__seaMediaPlayer_autoFullscreenNextAtom)
     const discreteControls = useAtomValue(__seaMediaPlayer_discreteControlsAtom)
     const autoSkipIntroOutro = useAtomValue(__seaMediaPlayer_autoSkipIntroOutroAtom)
     const [volume, setVolume] = useAtom(__seaMediaPlayer_volumeAtom)
@@ -324,6 +326,16 @@ export function SeaMediaPlayer(props: SeaMediaPlayerProps) {
         _onCanPlay?.(e, event)
 
         canPlayRef.current = true
+
+        
+        if (autoFullscreenNext && wentToNextEpisodeRef.current && process.env.NEXT_PUBLIC_PLATFORM === "desktop") {
+            logger("MEDIA PLAYER").info("Fullscreen via Auto-Fullscreen")
+            try {
+                playerRef.current?.enterFullscreen()
+                playerRef.current?.el?.focus()
+            } catch {
+            }
+        }
 
         wentToNextEpisodeRef.current = false
 


### PR DESCRIPTION
Addresses #312 and by proxy #186 too.

The PR is still a WIP since I've been having some issues with the feature myself regarding saving state.

Current Issues:
- UI state seems to not persist across app sessions (You close the .exe and open it again, the auto fullscreen option is set to false again)

Current Questions:
- I am able to confirm that this works on Windows, Desktop Version. I'm not sure about other platforms. Do we need testing for this?

https://github.com/user-attachments/assets/279bd170-3681-46ad-9193-f9874efdf856

---

Feel free to edit the PR ;)