### PR TITLE
feat(docker): Add CPU and NVIDIA Docker support with CI/CD

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,6 +16,23 @@ on:
 
 jobs:
   build-and-push-release:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "CPU"
+            target: "production-cpu-from-release"
+            tag_suffix: ""
+            platforms: "linux/amd64,linux/arm64"
+          - name: "VAAPI (Intel/AMD)"
+            target: "production-vaapi-from-release"
+            tag_suffix: "-vaapi"
+            platforms: "linux/amd64" # HWA images are often single-platform
+          - name: "NVIDIA"
+            target: "production-nvidia-from-release"
+            tag_suffix: "-nvidia"
+            platforms: "linux/amd64" # HWA images are often single-platform
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,17 +76,17 @@ jobs:
             echo "scope=${{ github.workflow }}-${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build and push multi-platform image
+      - name: Build and push ${{ matrix.name }} image
         uses: docker/build-push-action@v5
         with:
           context: .
-          target: production-release
-          platforms: linux/amd64,linux/arm64
+          target: ${{ matrix.target }}
+          platforms: ${{ matrix.platforms }}
           push: true
           build-args: |
             VERSION=${{ steps.get_version.outputs.version }}
           tags: |
-            ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:latest
-            ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:${{ steps.get_version.outputs.version }}
-          cache-from: type=gha,scope=${{ steps.cache_scope.outputs.scope }}
-          cache-to: type=gha,scope=${{ steps.cache_scope.outputs.scope }},mode=max
+            ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:latest${{ matrix.tag_suffix }}
+            ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:${{ steps.get_version.outputs.version }}${{ matrix.tag_suffix }}
+          cache-from: type=gha,scope=release-${{ matrix.target }}
+          cache-to: type=gha,scope=release-${{ matrix.target }},mode=max

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,44 @@
+name: Publish Release Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # Permission to push to GHCR
+    steps:
+      - name: Get latest release version
+        id: get_version
+        run: |
+          # The version is available from the event payload
+          echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU for multi-platform builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-platform image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: builder-release
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ steps.get_version.outputs.version }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/seanime:latest
+            ghcr.io/${{ github.repository_owner }}/seanime:${{ steps.get_version.outputs.version }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -3,21 +3,32 @@ name: Publish Release Docker Image
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to build (e.g., v2.8.5)"
+        required: true
 
 jobs:
   build-and-push-release:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write # Permission to push to GHCR
+      packages: write
     steps:
-      - name: Get latest release version
+      - name: Get release version
         id: get_version
         run: |
-          # The version is available from the event payload
-          echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          VERSION=${{ github.event.release.tag_name || github.event.inputs.version }}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Set up QEMU for multi-platform builds
+      - name: Convert owner to lowercase
+        id: string
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository_owner }}
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -40,5 +51,5 @@ jobs:
           build-args: |
             VERSION=${{ steps.get_version.outputs.version }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/seanime:latest
-            ghcr.io/${{ github.repository_owner }}/seanime:${{ steps.get_version.outputs.version }}
+            ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:latest
+            ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:${{ steps.get_version.outputs.version }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -24,14 +24,10 @@ jobs:
             target: "production-cpu-from-release"
             tag_suffix: ""
             platforms: "linux/amd64,linux/arm64"
-          - name: "VAAPI (Intel/AMD)"
-            target: "production-vaapi-from-release"
-            tag_suffix: "-vaapi"
-            platforms: "linux/amd64" # HWA images are often single-platform
           - name: "NVIDIA"
             target: "production-nvidia-from-release"
             tag_suffix: "-nvidia"
-            platforms: "linux/amd64" # HWA images are often single-platform
+            platforms: "linux/amd64"
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -21,6 +21,9 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Get release version
         id: get_version
         run: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,6 +8,11 @@ on:
       version:
         description: "Release tag to build (e.g., v2.8.5)"
         required: true
+      clear_cache:
+        description: "Clear build cache before running"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-and-push-release:
@@ -32,6 +37,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
@@ -41,11 +47,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Define cache scope
+        id: cache_scope
+        run: |
+          if [[ "${{ github.event.inputs.clear_cache }}" == "true" ]]; then
+            echo "scope=${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}" >> $GITHUB_OUTPUT
+          else
+            echo "scope=${{ github.workflow }}-${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push multi-platform image
         uses: docker/build-push-action@v5
         with:
           context: .
-          target: builder-release
+          target: production-release
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
@@ -53,3 +68,5 @@ jobs:
           tags: |
             ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:latest
             ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:${{ steps.get_version.outputs.version }}
+          cache-from: type=gha,scope=${{ steps.cache_scope.outputs.scope }}
+          cache-to: type=gha,scope=${{ steps.cache_scope.outputs.scope }},mode=max

--- a/.github/workflows/docket-development.yml
+++ b/.github/workflows/docket-development.yml
@@ -1,0 +1,40 @@
+name: Build Development Docker Image
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  build-and-push-dev:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # Permission to push to GHCR
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU for multi-platform builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-platform image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: builder-source
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/seanime:development
+            ghcr.io/${{ github.repository_owner }}/seanime:dev-${{ github.sha }}

--- a/.github/workflows/docket-development.yml
+++ b/.github/workflows/docket-development.yml
@@ -54,11 +54,11 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          target: production-source
+          target: production-cpu-from-source
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:development
             ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:dev-${{ github.sha }}
-          cache-from: type=gha,scope=${{ steps.cache_scope.outputs.scope }}
-          cache-to: type=gha,scope=${{ steps.cache_scope.outputs.scope }},mode=max
+          cache-from: type=gha,scope=dev-cpu
+          cache-to: type=gha,scope=dev-cpu,mode=max

--- a/.github/workflows/docket-development.yml
+++ b/.github/workflows/docket-development.yml
@@ -10,12 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write # Permission to push to GHCR
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU for multi-platform builds
+      - name: Convert owner to lowercase
+        id: string
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository_owner }}
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -36,5 +42,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/seanime:development
-            ghcr.io/${{ github.repository_owner }}/seanime:dev-${{ github.sha }}
+            ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:development
+            ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:dev-${{ github.sha }}

--- a/.github/workflows/docket-development.yml
+++ b/.github/workflows/docket-development.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: ["main"]
   workflow_dispatch:
+    inputs:
+      clear_cache:
+        description: "Clear build cache before running"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-and-push-dev:
@@ -25,6 +31,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
@@ -34,13 +41,24 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Define cache scope
+        id: cache_scope
+        run: |
+          if [[ "${{ github.event.inputs.clear_cache }}" == "true" ]]; then
+            echo "scope=${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}" >> $GITHUB_OUTPUT
+          else
+            echo "scope=${{ github.workflow }}-${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push multi-platform image
         uses: docker/build-push-action@v5
         with:
           context: .
-          target: builder-source
+          target: production-source
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:development
             ghcr.io/${{ steps.string.outputs.lowercase }}/seanime:dev-${{ github.sha }}
+          cache-from: type=gha,scope=${{ steps.cache_scope.outputs.scope }}
+          cache-to: type=gha,scope=${{ steps.cache_scope.outputs.scope }},mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ testdata/
 .DS_Store
 */.DS_Store
 
-Dockerfile
 Dockerfile.dev
 dev.dockerfile
 .dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN \
   "linux/arm64") ARCH="arm64" ;; \
   *) echo "Unsupported platform for release build: ${TARGETPLATFORM}" >&2; exit 1 ;; \
   esac; \
-  wget https://github.com/5rahim/seanime/releases/download/${VERSION}/seanime-${VERSION#v}_Linux_${ARCH}.tar.gz && \
+  wget https://github.com/Ju1-js/seanime/releases/download/${VERSION}/seanime-${VERSION#v}_Linux_${ARCH}.tar.gz && \
   tar -xzf seanime-*.tar.gz && \
   mv seanime seanime-server
 
@@ -22,7 +22,7 @@ FROM golang:1.24-alpine AS builder-source
 RUN apk add --no-cache git npm
 
 WORKDIR /src
-RUN git clone --depth 1 https://github.com/5rahim/seanime.git .
+RUN git clone --depth 1 https://github.com/Ju1-js/seanime.git .
 WORKDIR /src/seanime-web
 
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN go build -o seanime-server -trimpath -ldflags="-s -w"
 # Development builds from source
 FROM alpine:latest AS production-source
 
+RUN apk add --no-cache ffmpeg
+
 EXPOSE 43211
 
 RUN addgroup -S app && adduser -S -G app app
@@ -50,6 +52,8 @@ CMD ["./seanime"]
 
 # Release builds using pre-compiled binaries
 FROM alpine:latest AS production-release
+
+RUN apk add --no-cache ffmpeg
 
 EXPOSE 43211
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
-# Pre-compiled release binary
+# Builds the binary from the latest source code
+FROM golang:1.24-alpine AS builder-source
+
+RUN apk add --no-cache git npm
+
+WORKDIR /src
+RUN git clone --depth 1 https://github.com/Ju1-js/seanime.git .
+WORKDIR /src/seanime-web
+RUN npm install && npm run build
+WORKDIR /src
+RUN mkdir -p web && mv seanime-web/out/* web/
+RUN go mod download && go build -o seanime-server -trimpath -ldflags="-s -w"
+
+# Fetches a pre-compiled release binary
 FROM alpine:latest AS builder-release
 
 RUN apk add --no-cache curl
@@ -16,52 +29,46 @@ RUN \
   tar -xzf seanime-*.tar.gz && \
   mv seanime seanime-server
 
-# Binary from the latest source code
-FROM golang:1.24-alpine AS builder-source
 
-RUN apk add --no-cache git npm
-
-WORKDIR /src
-RUN git clone --depth 1 https://github.com/Ju1-js/seanime.git .
-WORKDIR /src/seanime-web
-
-RUN npm install
-RUN npm run build
-
-WORKDIR /src
-RUN mkdir -p web && mv seanime-web/out/* web/
-
-RUN go mod download
-RUN go build -o seanime-server -trimpath -ldflags="-s -w"
-
-# Development builds from source
-FROM alpine:latest AS production-source
-
+# --- Set 1: Built from SOURCE ---
+FROM alpine:latest AS production-cpu-from-source
 RUN apk add --no-cache ffmpeg
-
 EXPOSE 43211
-
 RUN addgroup -S app && adduser -S -G app app
 WORKDIR /app
 COPY --from=builder-source /src/seanime-server /app/seanime
-
 RUN chown -R app:app /app
 USER app
-
 CMD ["./seanime"]
 
-# Release builds using pre-compiled binaries
-FROM alpine:latest AS production-release
 
+# --- Set 2: Built from RELEASE ---
+FROM alpine:latest AS production-cpu-from-release
 RUN apk add --no-cache ffmpeg
-
 EXPOSE 43211
-
 RUN addgroup -S app && adduser -S -G app app
 WORKDIR /app
 COPY --from=builder-release /seanime-server /app/seanime
-
 RUN chown -R app:app /app
 USER app
+CMD ["./seanime"]
 
+FROM debian:12-slim AS production-vaapi-from-release
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg vainfo intel-media-va-driver-non-free i965-va-driver mesa-va-drivers && rm -rf /var/lib/apt/lists/*
+EXPOSE 43211
+RUN addgroup --system app && adduser --system --ingroup app --no-create-home app
+WORKDIR /app
+COPY --from=builder-release /seanime-server /app/seanime
+RUN chown -R app:app /app
+USER app
+CMD ["./seanime"]
+
+FROM nvidia/cuda:12.1.1-base-ubuntu22.04 AS production-nvidia-from-release
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
+EXPOSE 43211
+RUN addgroup --system app && adduser --system --ingroup app --no-create-home app
+WORKDIR /app
+COPY --from=builder-release /seanime-server /app/seanime
+RUN chown -R app:app /app
+USER app
 CMD ["./seanime"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,15 +53,6 @@ RUN chown -R app:app /app
 USER app
 CMD ["./seanime"]
 
-FROM debian:12-slim AS production-vaapi-from-release
-RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg vainfo intel-media-va-driver-non-free i965-va-driver mesa-va-drivers && rm -rf /var/lib/apt/lists/*
-EXPOSE 43211
-RUN addgroup --system app && adduser --system --ingroup app --no-create-home app
-WORKDIR /app
-COPY --from=builder-release /seanime-server /app/seanime
-RUN chown -R app:app /app
-USER app
-CMD ["./seanime"]
 
 FROM nvidia/cuda:12.1.1-base-ubuntu22.04 AS production-nvidia-from-release
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.24-alpine AS builder-source
 RUN apk add --no-cache git npm
 
 WORKDIR /src
-RUN git clone --depth 1 https://github.com/Ju1-js/seanime.git .
+RUN git clone --depth 1 https://github.com/5rahim/seanime.git .
 WORKDIR /src/seanime-web
 RUN npm install && npm run build
 WORKDIR /src
@@ -25,7 +25,7 @@ RUN \
   "linux/arm64") ARCH="arm64" ;; \
   *) echo "Unsupported platform for release build: ${TARGETPLATFORM}" >&2; exit 1 ;; \
   esac; \
-  wget https://github.com/Ju1-js/seanime/releases/download/${VERSION}/seanime-${VERSION#v}_Linux_${ARCH}.tar.gz && \
+  wget https://github.com/5rahim/seanime/releases/download/${VERSION}/seanime-${VERSION#v}_Linux_${ARCH}.tar.gz && \
   tar -xzf seanime-*.tar.gz && \
   mv seanime seanime-server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,32 +13,26 @@ RUN \
   esac; \
   wget https://github.com/5rahim/seanime/releases/download/${VERSION}/seanime-${VERSION#v}_Linux_${ARCH}.tar.gz && \
   tar -xzf seanime-*.tar.gz && \
-  # Give the binary a consistent name
   mv seanime seanime-server
 
 # Build from source code for development
-FROM golang:1.22-alpine AS builder-source
+FROM golang:1.24-alpine AS builder-source
 
 RUN apk add --no-cache git npm
-
-# This step is no longer necessary as we will use npm directly.
-#   bun should have better performance, but npm is more widely supported.
-# RUN npm install -g bun
 
 WORKDIR /src
 RUN git clone --depth 1 https://github.com/5rahim/seanime.git .
 WORKDIR /src/seanime-web
 
-# RUN bun install
+# Install dependencies and build the web interface
 RUN npm install
-# RUN bun run build
 RUN npm run build
 
 WORKDIR /src
 RUN mkdir -p web && mv seanime-web/out/* web/
 
 RUN go mod download
-RUN CGO_ENABLED=0 go build -o seanime-server -trimpath -ldflags="-s -w" cmd/seanime/main.go
+RUN CGO_ENABLED=0 go build -o seanime-server -trimpath -ldflags="-s -w" ./cmd/seanime/main.go
 
 # Create the minimal production image
 FROM alpine:latest AS production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM alpine:latest AS builder-release
+
+RUN apk add --no-cache curl
+
+ARG VERSION
+ARG TARGETPLATFORM
+
+RUN \
+  case ${TARGETPLATFORM} in \
+  "linux/amd64") ARCH="x86_64" ;; \
+  "linux/arm64") ARCH="arm64" ;; \
+  *) echo "Unsupported platform for release build: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+  esac; \
+  wget https://github.com/5rahim/seanime/releases/download/${VERSION}/seanime-${VERSION#v}_Linux_${ARCH}.tar.gz && \
+  tar -xzf seanime-*.tar.gz && \
+  # Give the binary a consistent name
+  mv seanime seanime-server
+
+# Build from source code for development
+FROM golang:1.22-alpine AS builder-source
+
+RUN apk add --no-cache git npm
+
+# This step is no longer necessary as we will use npm directly.
+#   bun should have better performance, but npm is more widely supported.
+# RUN npm install -g bun
+
+WORKDIR /src
+RUN git clone --depth 1 https://github.com/5rahim/seanime.git .
+WORKDIR /src/seanime-web
+
+# RUN bun install
+RUN npm install
+# RUN bun run build
+RUN npm run build
+
+WORKDIR /src
+RUN mkdir -p web && mv seanime-web/out/* web/
+
+RUN go mod download
+RUN CGO_ENABLED=0 go build -o seanime-server -trimpath -ldflags="-s -w" cmd/seanime/main.go
+
+# Create the minimal production image
+FROM alpine:latest AS production
+
+RUN addgroup -S app && adduser -S -G app app
+WORKDIR /app
+COPY --from=builder-source /src/seanime-server /app/seanime
+COPY --from=builder-source /src/web /app/web
+
+RUN chown -R app:app /app
+USER app
+
+EXPOSE 43211
+
+CMD ["./seanime"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,41 +1,86 @@
-# ========================================================
-# Docker Compose for Seanime
-# --------------------------------------------------------
-# Instructions:
-# 1. Uncomment ONE of the services below (cpu or nvidia).
-# 2. Run 'docker-compose up -d'.
-# ========================================================
+# ===================================================================================
+# Docker Compose for Seanime Media Stack
+# -----------------------------------------------------------------------------------
+# This file provides configurations for running Seanime and its dependencies.
+#
+# FULL STACK (Recommended):
+# 1. Uncomment the 'seanime' service AND one torrent client (e.g., 'qbittorrent').
+# 2. In the Seanime UI, connect to the torrent client using its service name, e.g.,
+#    Host: http://qbittorrent
+#    Port: 8080
+#
+# SEANIME ONLY (Connecting to a client on your Host PC):
+# 1. ONLY uncomment the 'seanime' service.
+# 2. Add the 'extra_hosts' block to it (see commented example).
+# 3. In the Seanime UI, connect using: http://host.docker.internal:<PORT>
+# ===================================================================================
 
 services:
-  # --- Option 1: Default CPU-only instance (should work on any system) ---
+  # --- SEANIME CORE SERVICE ---
   seanime:
     image: ghcr.io/5rahim/seanime:latest
     container_name: seanime
     restart: unless-stopped
     ports:
+      # Exposes the Seanime UI on your host
       - "43211:43211"
     environment:
       - SEANIME_SERVER_HOST=0.0.0.0
       - SEANIME_DATA_DIR=/data
     volumes:
+      # For Seanime's persistent database and metadata
       - ./seanime-data:/data
+      # Shared downloads folder (MUST match the torrent client's downloads volume)
+      - ./downloads:/downloads
+    # --- Uncomment below to connect to a torrent client on your HOST PC ---
+    # extra_hosts:
+    #   - "host.docker.internal:host-gateway"
 
-  # --- Option 2: NVIDIA GPU instance (for NVENC hardware transcoding) ---
-  # seanime-nvidia:
-  #   image: ghcr.io/5rahim/seanime:latest-nvidia # Note the '-nvidia' tag
-  #   container_name: seanime-nvidia
-  #   restart: unless-stopped
-  #   ports:
-  #     - "43211:43211"
-  #   environment:
-  #     - SEANIME_SERVER_HOST=0.0.0.0
-  #     - SEANIME_DATA_DIR=/data
-  #   volumes:
-  #     - ./seanime-data:/data
-  #   deploy:
-  #     resources:
-  #       reservations:
-  #         devices:
-  #           - driver: nvidia
-  #             count: 1
-  #             capabilities: [gpu]
+
+  # --- TORRENT CLIENTS (Choose ONE) ---
+
+  # Option A: qBittorrent
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:latest
+    container_name: qbittorrent
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      - WEBUI_PORT=8080
+    ports:
+      # Exposes the qBittorrent Web UI on your host
+      - "8080:8080"
+      - "6881:6881"
+      - "6881:6881/udp"
+    volumes:
+      # For qBittorrent's persistent configuration
+      - ./qbittorrent-config:/config
+      # Shared downloads folder (MUST match Seanime's downloads volume)
+      - ./downloads:/downloads
+
+  # Option B: Transmission
+  transmission:
+    image: lscr.io/linuxserver/transmission:latest
+    container_name: transmission
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+    ports:
+      # Exposes the Transmission Web UI on your host
+      - "9091:9091"
+      - "51413:51413"
+      - "51413:51413/udp"
+    volumes:
+      # For Transmission's persistent configuration
+      - ./transmission-config:/config
+      # Shared downloads folder
+      - ./downloads:/downloads
+      # For files you want to watch to auto-add torrents
+      - ./watch:/watch
+
+# Note: The 'services' defined above automatically share a network and can
+#       communicate using their service names (e.g., 'seanime', 'qbittorrent').

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,20 @@
+# ============================================================================
+# Docker Compose for Seanime
+# ----------------------------------------------------------------------------
+# This file provides configurations for running Seanime with Docker.
+#
+# Instructions:
+# 1. Uncomment ONE of the services below (cpu, nvidia, or vaapi) that matches
+#    your hardware. Do NOT run more than one at a time.
+# 2. Update the image tag if you want a specific version (e.g., v2.8.5).
+# 3. Run 'docker-compose up -d' in your terminal.
+# 4. Your persistent data will be stored in a 'seanime-data' folder.
+# ============================================================================
+
 services:
+  # --- Option 1: Default CPU-only instance (works on any system) ---
   seanime:
-    image: ghcr.io/5rahim/seanime:latest 
+    image: ghcr.io/5rahim/seanime:latest
     container_name: seanime
     restart: unless-stopped
     ports:
@@ -10,3 +24,43 @@ services:
       - SEANIME_DATA_DIR=/data
     volumes:
       - ./seanime-data:/data
+
+  # --- Option 2: NVIDIA GPU instance (for NVENC hardware transcoding) ---
+  # Uncomment the block below if you have an NVIDIA GPU and the NVIDIA Container Toolkit installed.
+  #
+  # seanime-nvidia:
+  #   image: ghcr.io/5rahim/seanime:latest-nvidia # Note the '-nvidia' tag
+  #   container_name: seanime-nvidia
+  #   restart: unless-stopped
+  #   ports:
+  #     - "43211:43211"
+  #   environment:
+  #     - SEANIME_SERVER_HOST=0.0.0.0
+  #     - SEANIME_DATA_DIR=/data
+  #   volumes:
+  #     - ./seanime-data:/data
+  #   deploy:
+  #     resources:
+  #       reservations:
+  #         devices:
+  #           - driver: nvidia
+  #             count: 1
+  #             capabilities: [gpu]
+
+  # --- Option 3: VAAPI instance (for Intel QSV / AMD hardware transcoding) ---
+  # Uncomment the block below if you have a supported Intel or AMD GPU.
+  #
+  # seanime-vaapi:
+  #   image: ghcr.io/5rahim/seanime:latest-vaapi # Note the '-vaapi' tag
+  #   container_name: seanime-vaapi
+  #   restart: unless-stopped
+  #   ports:
+  #     - "43211:43211"
+  #   environment:
+  #     - SEANIME_SERVER_HOST=0.0.0.0
+  #     - SEANIME_DATA_DIR=/data
+  #   volumes:
+  #     - ./seanime-data:/data
+  #   devices:
+  #     # This mounts the host's video acceleration device into the container.
+  #     - /dev/dri:/dev/dri

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,13 @@
-# ============================================================================
+# ========================================================
 # Docker Compose for Seanime
-# ----------------------------------------------------------------------------
-# This file provides configurations for running Seanime with Docker.
-#
+# --------------------------------------------------------
 # Instructions:
-# 1. Uncomment ONE of the services below (cpu, nvidia, or vaapi) that matches
-#    your hardware. Do NOT run more than one at a time.
-# 2. Update the image tag if you want a specific version (e.g., v2.8.5).
-# 3. Run 'docker-compose up -d' in your terminal.
-# 4. Your persistent data will be stored in a 'seanime-data' folder.
-# ============================================================================
+# 1. Uncomment ONE of the services below (cpu or nvidia).
+# 2. Run 'docker-compose up -d'.
+# ========================================================
 
 services:
-  # --- Option 1: Default CPU-only instance (works on any system) ---
+  # --- Option 1: Default CPU-only instance (should work on any system) ---
   seanime:
     image: ghcr.io/5rahim/seanime:latest
     container_name: seanime
@@ -26,8 +21,6 @@ services:
       - ./seanime-data:/data
 
   # --- Option 2: NVIDIA GPU instance (for NVENC hardware transcoding) ---
-  # Uncomment the block below if you have an NVIDIA GPU and the NVIDIA Container Toolkit installed.
-  #
   # seanime-nvidia:
   #   image: ghcr.io/5rahim/seanime:latest-nvidia # Note the '-nvidia' tag
   #   container_name: seanime-nvidia
@@ -46,21 +39,3 @@ services:
   #           - driver: nvidia
   #             count: 1
   #             capabilities: [gpu]
-
-  # --- Option 3: VAAPI instance (for Intel QSV / AMD hardware transcoding) ---
-  # Uncomment the block below if you have a supported Intel or AMD GPU.
-  #
-  # seanime-vaapi:
-  #   image: ghcr.io/5rahim/seanime:latest-vaapi # Note the '-vaapi' tag
-  #   container_name: seanime-vaapi
-  #   restart: unless-stopped
-  #   ports:
-  #     - "43211:43211"
-  #   environment:
-  #     - SEANIME_SERVER_HOST=0.0.0.0
-  #     - SEANIME_DATA_DIR=/data
-  #   volumes:
-  #     - ./seanime-data:/data
-  #   devices:
-  #     # This mounts the host's video acceleration device into the container.
-  #     - /dev/dri:/dev/dri

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  seanime:
+    image: ghcr.io/Ju1-js/seanime:latest 
+    container_name: seanime
+    restart: unless-stopped
+    ports:
+      - "43211:43211"
+    environment:
+      - SEANIME_SERVER_HOST=0.0.0.0
+      - SEANIME_DATA_DIR=/data
+    volumes:
+      - ./seanime-data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,43 +3,54 @@
 # -----------------------------------------------------------------------------------
 # This file provides configurations for running Seanime and its dependencies.
 #
-# FULL STACK (Recommended):
-# 1. Uncomment the 'seanime' service AND one torrent client (e.g., 'qbittorrent').
-# 2. In the Seanime UI, connect to the torrent client using its service name, e.g.,
-#    Host: http://qbittorrent
-#    Port: 8080
-#
-# SEANIME ONLY (Connecting to a client on your Host PC):
-# 1. ONLY uncomment the 'seanime' service.
-# 2. Add the 'extra_hosts' block to it (see commented example).
-# 3. In the Seanime UI, connect using: http://host.docker.internal:<PORT>
+# Instructions:
+# 1. Choose your Seanime version: Uncomment EITHER 'seanime-cpu' OR 'seanime-nvidia'.
+# 2. Choose your torrent client: Uncomment EITHER 'qbittorrent' OR 'transmission'.
+# 3. The service names (e.g., 'http://qbittorrent') are used for communication.
+# 4. Run 'docker-compose up -d'.
 # ===================================================================================
 
 services:
-  # --- SEANIME CORE SERVICE ---
-  seanime:
+  # --- SEANIME SERVICES (Choose ONE) ---
+
+  # Option A: CPU-only instance (works on any system)
+  seanime-cpu:
     image: ghcr.io/5rahim/seanime:latest
-    container_name: seanime
+    container_name: seanime-cpu
     restart: unless-stopped
     ports:
-      # Exposes the Seanime UI on your host
       - "43211:43211"
     environment:
       - SEANIME_SERVER_HOST=0.0.0.0
       - SEANIME_DATA_DIR=/data
     volumes:
-      # For Seanime's persistent database and metadata
       - ./seanime-data:/data
-      # Shared downloads folder (MUST match the torrent client's downloads volume)
       - ./downloads:/downloads
-    # --- Uncomment below to connect to a torrent client on your HOST PC ---
-    # extra_hosts:
-    #   - "host.docker.internal:host-gateway"
+  # Option B: NVIDIA GPU instance (for NVENC hardware transcoding)
+  # seanime-nvidia:
+  #   image: ghcr.io/5rahim/seanime:latest-nvidia # Note the '-nvidia' tag
+  #   container_name: seanime-nvidia
+  #   restart: unless-stopped
+  #   ports:
+  #     - "43211:43211"
+  #   environment:
+  #     - SEANIME_SERVER_HOST=0.0.0.0
+  #     - SEANIME_DATA_DIR=/data
+  #   volumes:
+  #     - ./seanime-data:/data
+  #     - ./downloads:/downloads
+  #   deploy:
+  #     resources:
+  #       reservations:
+  #         devices:
+  #           - driver: nvidia
+  #             count: 1
+  #             capabilities: [gpu]
 
 
   # --- TORRENT CLIENTS (Choose ONE) ---
 
-  # Option A: qBittorrent
+  # Option 1: qBittorrent
   # qbittorrent:
   #   image: lscr.io/linuxserver/qbittorrent:latest
   #   container_name: qbittorrent
@@ -50,17 +61,14 @@ services:
   #     - TZ=Etc/UTC
   #     - WEBUI_PORT=8080
   #   ports:
-  #     # Exposes the qBittorrent Web UI on your host
   #     - "8080:8080"
   #     - "6881:6881"
   #     - "6881:6881/udp"
   #   volumes:
-  #     # For qBittorrent's persistent configuration
   #     - ./qbittorrent-config:/config
-  #     # Shared downloads folder (MUST match Seanime's downloads volume)
   #     - ./downloads:/downloads
 
-  # Option B: Transmission
+  # Option 2: Transmission
   # transmission:
   #   image: lscr.io/linuxserver/transmission:latest
   #   container_name: transmission
@@ -70,17 +78,10 @@ services:
   #     - PGID=1000
   #     - TZ=Etc/UTC
   #   ports:
-  #     # Exposes the Transmission Web UI on your host
   #     - "9091:9091"
   #     - "51413:51413"
   #     - "51413:51413/udp"
   #   volumes:
-  #     # For Transmission's persistent configuration
   #     - ./transmission-config:/config
-  #     # Shared downloads folder
   #     - ./downloads:/downloads
-  #     # For files you want to watch to auto-add torrents
   #     - ./watch:/watch
-
-# Note: The 'services' defined above automatically share a network and can
-#       communicate using their service names (e.g., 'seanime', 'qbittorrent').

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   seanime:
-    image: ghcr.io/Ju1-js/seanime:latest 
+    image: ghcr.io/5rahim/seanime:latest 
     container_name: seanime
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,47 +40,47 @@ services:
   # --- TORRENT CLIENTS (Choose ONE) ---
 
   # Option A: qBittorrent
-  qbittorrent:
-    image: lscr.io/linuxserver/qbittorrent:latest
-    container_name: qbittorrent
-    restart: unless-stopped
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=Etc/UTC
-      - WEBUI_PORT=8080
-    ports:
-      # Exposes the qBittorrent Web UI on your host
-      - "8080:8080"
-      - "6881:6881"
-      - "6881:6881/udp"
-    volumes:
-      # For qBittorrent's persistent configuration
-      - ./qbittorrent-config:/config
-      # Shared downloads folder (MUST match Seanime's downloads volume)
-      - ./downloads:/downloads
+  # qbittorrent:
+  #   image: lscr.io/linuxserver/qbittorrent:latest
+  #   container_name: qbittorrent
+  #   restart: unless-stopped
+  #   environment:
+  #     - PUID=1000
+  #     - PGID=1000
+  #     - TZ=Etc/UTC
+  #     - WEBUI_PORT=8080
+  #   ports:
+  #     # Exposes the qBittorrent Web UI on your host
+  #     - "8080:8080"
+  #     - "6881:6881"
+  #     - "6881:6881/udp"
+  #   volumes:
+  #     # For qBittorrent's persistent configuration
+  #     - ./qbittorrent-config:/config
+  #     # Shared downloads folder (MUST match Seanime's downloads volume)
+  #     - ./downloads:/downloads
 
   # Option B: Transmission
-  transmission:
-    image: lscr.io/linuxserver/transmission:latest
-    container_name: transmission
-    restart: unless-stopped
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=Etc/UTC
-    ports:
-      # Exposes the Transmission Web UI on your host
-      - "9091:9091"
-      - "51413:51413"
-      - "51413:51413/udp"
-    volumes:
-      # For Transmission's persistent configuration
-      - ./transmission-config:/config
-      # Shared downloads folder
-      - ./downloads:/downloads
-      # For files you want to watch to auto-add torrents
-      - ./watch:/watch
+  # transmission:
+  #   image: lscr.io/linuxserver/transmission:latest
+  #   container_name: transmission
+  #   restart: unless-stopped
+  #   environment:
+  #     - PUID=1000
+  #     - PGID=1000
+  #     - TZ=Etc/UTC
+  #   ports:
+  #     # Exposes the Transmission Web UI on your host
+  #     - "9091:9091"
+  #     - "51413:51413"
+  #     - "51413:51413/udp"
+  #   volumes:
+  #     # For Transmission's persistent configuration
+  #     - ./transmission-config:/config
+  #     # Shared downloads folder
+  #     - ./downloads:/downloads
+  #     # For files you want to watch to auto-add torrents
+  #     - ./watch:/watch
 
 # Note: The 'services' defined above automatically share a network and can
 #       communicate using their service names (e.g., 'seanime', 'qbittorrent').


### PR DESCRIPTION
This PR implements a robust Docker solution for Seanime, introducing automated builds for both CPU and NVIDIA GPU deployments. I've also included ffmpeg in both images.

### Key Features Implemented:
*   **Dockerfile Architecture:** A multi-stage `Dockerfile` supporting:
    *   **Dual Build Logic:** Builds from either source code (for dev) or pre-compiled binaries (for releases).
    *   **Targeted Images:** Produces an optimized CPU image and an `-nvidia` tagged image for NVENC.
*   **CI/CD Automation:**
    *   **Development Workflow:** Builds a `:development` image from source on pushes to `main`.
    *   **Release Workflow:** Uses a build matrix to publish `:latest` and `:latest-nvidia` images from release assets.
    *   **Build Caching:** Implemented in both workflows for faster subsequent runs.
*   **`docker-compose.yml`:** An easy-to-use Compose file is included with clear instructions for running either the CPU or NVIDIA variant.

### Notes:
*   **Scope:** To ensure a stable and testable contribution, support for VAAPI (Intel/AMD) was removed after encountering build failures with driver dependencies. This PR focuses on providing a rock-solid solution for CPU and NVIDIA users. VAAPI can be revisited in a future contribution.
*   **Documentation Update Required:** The docs at `/docs/getting-started` (Docker Server "here" link) and `/docs/config` (environment variables) will need to be updated to reflect these new Docker options. (The SEANIME_HOST/PORT should be SEANIME_SERVER_HOST/PORT)

Closes #321  