### PR TITLE
refactor: remove unreadOnly from params and implement separate persistent atom for manga filtering

### DIFF
--- a/seanime-web/src/app/(main)/anilist/_lib/handle-user-anilist-lists.ts
+++ b/seanime-web/src/app/(main)/anilist/_lib/handle-user-anilist-lists.ts
@@ -11,7 +11,6 @@ import { useDebounce } from "use-debounce"
 export const MYLISTS_DEFAULT_PARAMS: CollectionParams<"anime"> | CollectionParams<"manga"> = {
     ...DEFAULT_COLLECTION_PARAMS,
     sorting: "SCORE_DESC",
-    unreadOnly: false,
     continueWatchingOnly: false,
 }
 

--- a/seanime-web/src/app/(main)/manga/_screens/manga-library-view.tsx
+++ b/seanime-web/src/app/(main)/manga/_screens/manga-library-view.tsx
@@ -6,7 +6,7 @@ import { MediaGenreSelector } from "@/app/(main)/_features/media/_components/med
 import { SeaCommandInjectableItem, useSeaCommandInject } from "@/app/(main)/_features/sea-command/use-inject"
 import { seaCommand_compareMediaTitles } from "@/app/(main)/_features/sea-command/utils"
 import { __mangaLibraryHeaderImageAtom, __mangaLibraryHeaderMangaAtom } from "@/app/(main)/manga/_components/library-header"
-import { __mangaLibrary_paramsAtom, __mangaLibrary_paramsInputAtom } from "@/app/(main)/manga/_lib/handle-manga-collection"
+import { __mangaLibrary_paramsAtom, __mangaLibrary_paramsInputAtom, __manga_unreadOnlyAtom } from "@/app/(main)/manga/_lib/handle-manga-collection"
 import { PageWrapper } from "@/components/shared/page-wrapper"
 import { TextGenerateEffect } from "@/components/shared/text-generate-effect"
 import { IconButton } from "@/components/ui/button"
@@ -162,6 +162,7 @@ const CollectionListItem = memo(({ list, storedProviders }: { list: Manga_Collec
     const [currentHeaderImage, setCurrentHeaderImage] = useAtom(__mangaLibraryHeaderImageAtom)
     const headerManga = useAtomValue(__mangaLibraryHeaderMangaAtom)
     const [params, setParams] = useAtom(__mangaLibrary_paramsAtom)
+    const [unreadOnly, setUnreadOnly] = useAtom(__manga_unreadOnlyAtom)
     const router = useRouter()
 
     const { mutate: refetchMangaChapterContainers, isPending: isRefetchingMangaChapterContainers } = useRefetchMangaChapterContainers()
@@ -219,9 +220,9 @@ const CollectionListItem = memo(({ list, storedProviders }: { list: Manga_Collec
                             size="xs"
                             className="mt-1"
                             icon={<BiDotsVertical />}
-                            // loading={isRefetchingMangaChapterContainers}
+                        // loading={isRefetchingMangaChapterContainers}
                         />
-                        {params.unreadOnly && <div className="absolute -top-1 -right-1 bg-[--blue] size-2 rounded-full"></div>}
+                        {unreadOnly && <div className="absolute -top-1 -right-1 bg-[--blue] size-2 rounded-full"></div>}
                         {isRefetchingMangaChapterContainers &&
                             <div className="absolute -top-1 -right-1 bg-[--orange] size-3 rounded-full animate-ping"></div>}
                     </div>}
@@ -240,13 +241,10 @@ const CollectionListItem = memo(({ list, storedProviders }: { list: Manga_Collec
                     </DropdownMenuItem>
                     <DropdownMenuItem
                         onClick={() => {
-                            setParams(draft => {
-                                draft.unreadOnly = !draft.unreadOnly
-                                return
-                            })
+                            setUnreadOnly(!unreadOnly)
                         }}
                     >
-                        <LuBookOpenCheck /> {params.unreadOnly ? "Show all" : "Unread chapters only"}
+                        <LuBookOpenCheck /> {unreadOnly ? "Show all" : "Unread chapters only"}
                     </DropdownMenuItem>
                 </DropdownMenu>}
 

--- a/seanime-web/src/lib/helpers/filtering.ts
+++ b/seanime-web/src/lib/helpers/filtering.ts
@@ -36,9 +36,9 @@ type CollectionSorting<T extends CollectionType> = BaseCollectionSorting | (T ex
     | "AIRDATE"
     | "AIRDATE_DESC"
     : T extends "manga" ?
-        "PROGRESS"
-        | "PROGRESS_DESC"
-        : never)
+    "PROGRESS"
+    | "PROGRESS_DESC"
+    : never)
 
 
 type ContinueWatchingSorting =
@@ -113,7 +113,7 @@ export type CollectionParams<T extends CollectionType> = {
     year: string | null
     isAdult: boolean
 } & (T extends "manga" ? {
-    unreadOnly: boolean
+    // unreadOnly removed - now handled by separate persistent atom
 } : T extends "anime" ? {
     continueWatchingOnly: boolean
 } : never)
@@ -149,7 +149,6 @@ export const DEFAULT_MANGA_COLLECTION_PARAMS: CollectionParams<"manga"> = {
     season: null,
     year: null,
     isAdult: false,
-    unreadOnly: false,
 }
 
 
@@ -411,12 +410,13 @@ export function filterMangaCollectionEntries<T extends Anime_LibraryCollectionEn
     storedProviders: Record<string, string> | null | undefined,
     storedProviderFilters: Record<number, MangaEntryFilters> | null | undefined,
     latestChapterNumbers: Record<number, Manga_MangaLatestChapterNumberItem[]> | null | undefined,
+    unreadOnly?: boolean,
 ) {
     if (!latestChapterNumbers || !storedProviders || !storedProviderFilters) return []
     let arr = filterCollectionEntries("manga", entries, params, showAdultContent)
 
 
-    if (params.unreadOnly) {
+    if (unreadOnly) {
         arr = arr.filter(n => {
             const latestChapterNumber = getMangaEntryLatestChapterNumber(n.media?.id!, latestChapterNumbers, storedProviders, storedProviderFilters)
             const mangaChapterCount = latestChapterNumber || 999999


### PR DESCRIPTION
I tried to make the cleaner, simliar, and more maintable way of implementing show persistant unread mangas.

Sorry for the double pull request, removed a file in the commit which was not relavent to this PR.