### PR TITLE
feat: Keybord Shortcuts to change Double-page-offset

### DIFF
--- a/seanime-web/src/app/(main)/manga/_containers/chapter-reader/chapter-reader-settings.tsx
+++ b/seanime-web/src/app/(main)/manga/_containers/chapter-reader/chapter-reader-settings.tsx
@@ -591,10 +591,10 @@ export function ChapterReaderSettings(props: ChapterReaderSettingsProps) {
                                 key: "s",
                                 label: "Switch page stretch",
                             }, {
-                                key: "+ or =",
+                                key: "shift+right",
                                 label: "Increment manga offset",
                             }, {
-                                key: "-",
+                                key: "shift+left",
                                 label: "Decrement manga offset",
                             }].map(item => {
                                 return (

--- a/seanime-web/src/app/(main)/manga/_containers/chapter-reader/chapter-reader-settings.tsx
+++ b/seanime-web/src/app/(main)/manga/_containers/chapter-reader/chapter-reader-settings.tsx
@@ -591,7 +591,7 @@ export function ChapterReaderSettings(props: ChapterReaderSettingsProps) {
                                 key: "s",
                                 label: "Switch page stretch",
                             }, {
-                                key: "+",
+                                key: "+/=",
                                 label: "Increment manga offset",
                             }, {
                                 key: "-",

--- a/seanime-web/src/app/(main)/manga/_containers/chapter-reader/chapter-reader-settings.tsx
+++ b/seanime-web/src/app/(main)/manga/_containers/chapter-reader/chapter-reader-settings.tsx
@@ -578,6 +578,24 @@ export function ChapterReaderSettings(props: ChapterReaderSettingsProps) {
                             }, {
                                 key: "b",
                                 label: "Toggle bottom bar visibility",
+                            }, {
+                                key: "m",
+                                label: "Switch reading mode",
+                            }, {
+                                key: "d",
+                                label: "Switch reading direction",
+                            }, {
+                                key: "f",
+                                label: "Switch page fit",
+                            }, {
+                                key: "s",
+                                label: "Switch page stretch",
+                            }, {
+                                key: "+",
+                                label: "Increment manga offset",
+                            }, {
+                                key: "-",
+                                label: "Decrement manga offset",
                             }].map(item => {
                                 return (
                                     <div className="flex gap-2 items-center" key={item.key}>

--- a/seanime-web/src/app/(main)/manga/_containers/chapter-reader/chapter-reader-settings.tsx
+++ b/seanime-web/src/app/(main)/manga/_containers/chapter-reader/chapter-reader-settings.tsx
@@ -591,7 +591,7 @@ export function ChapterReaderSettings(props: ChapterReaderSettingsProps) {
                                 key: "s",
                                 label: "Switch page stretch",
                             }, {
-                                key: "+/=",
+                                key: "+ or =",
                                 label: "Increment manga offset",
                             }, {
                                 key: "-",

--- a/seanime-web/src/app/(main)/manga/_lib/handle-chapter-reader.ts
+++ b/seanime-web/src/app/(main)/manga/_lib/handle-chapter-reader.ts
@@ -381,6 +381,7 @@ export function useSwitchSettingsWithKeys() {
         mousetrap.bind("f", () => switchValue(pageFit, Object.values(MangaPageFit), setPageFit))
         mousetrap.bind("s", () => switchValue(pageStretch, Object.values(MangaPageStretch), setPageStretch))
         mousetrap.bind("=", () => incrementOffset())
+        mousetrap.bind("+", () => incrementOffset())
         mousetrap.bind("-", () => decrementOffset())
 
         return () => {

--- a/seanime-web/src/app/(main)/manga/_lib/handle-chapter-reader.ts
+++ b/seanime-web/src/app/(main)/manga/_lib/handle-chapter-reader.ts
@@ -359,6 +359,7 @@ export function useSwitchSettingsWithKeys() {
     const [readingDirection, setReadingDirection] = useAtom(__manga_readingDirectionAtom)
     const [pageFit, setPageFit] = useAtom(__manga_pageFitAtom)
     const [pageStretch, setPageStretch] = useAtom(__manga_pageStretchAtom)
+    const [doublePageOffset, setDoublePageOffset] = useAtom(__manga_doublePageOffsetAtom)
 
     const switchValue = (currentValue: string, possibleValues: string[], setValue: (v: any) => void) => {
         const currentIndex = possibleValues.indexOf(currentValue)
@@ -366,19 +367,31 @@ export function useSwitchSettingsWithKeys() {
         setValue(possibleValues[nextIndex])
     }
 
+    const incrementOffset = () => {
+        setDoublePageOffset(prev => Math.max(0, prev + 1))
+    }
+
+    const decrementOffset = () => {
+        setDoublePageOffset(prev => Math.max(0, prev - 1))
+    }
+
     React.useEffect(() => {
         mousetrap.bind("m", () => switchValue(readingMode, Object.values(MangaReadingMode), setReadingMode))
         mousetrap.bind("d", () => switchValue(readingDirection, Object.values(MangaReadingDirection), setReadingDirection))
         mousetrap.bind("f", () => switchValue(pageFit, Object.values(MangaPageFit), setPageFit))
         mousetrap.bind("s", () => switchValue(pageStretch, Object.values(MangaPageStretch), setPageStretch))
+        mousetrap.bind("=", () => incrementOffset())
+        mousetrap.bind("-", () => decrementOffset())
 
         return () => {
             mousetrap.unbind("m")
             mousetrap.unbind("d")
             mousetrap.unbind("f")
             mousetrap.unbind("s")
+            mousetrap.unbind("=")
+            mousetrap.unbind("-")
         }
-    }, [readingMode, readingDirection, pageFit, pageStretch])
+    }, [readingMode, readingDirection, pageFit, pageStretch, doublePageOffset])
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/seanime-web/src/app/(main)/manga/_lib/handle-chapter-reader.ts
+++ b/seanime-web/src/app/(main)/manga/_lib/handle-chapter-reader.ts
@@ -380,18 +380,16 @@ export function useSwitchSettingsWithKeys() {
         mousetrap.bind("d", () => switchValue(readingDirection, Object.values(MangaReadingDirection), setReadingDirection))
         mousetrap.bind("f", () => switchValue(pageFit, Object.values(MangaPageFit), setPageFit))
         mousetrap.bind("s", () => switchValue(pageStretch, Object.values(MangaPageStretch), setPageStretch))
-        mousetrap.bind("=", () => incrementOffset())
-        mousetrap.bind("+", () => incrementOffset())
-        mousetrap.bind("-", () => decrementOffset())
+        mousetrap.bind("shift+right", () => incrementOffset())
+        mousetrap.bind("shift+left", () => decrementOffset())
 
         return () => {
             mousetrap.unbind("m")
             mousetrap.unbind("d")
             mousetrap.unbind("f")
             mousetrap.unbind("s")
-            mousetrap.unbind("=")
-            mousetrap.unbind("+")
-            mousetrap.unbind("-")
+            mousetrap.unbind("shift+right")
+            mousetrap.unbind("shift+left")
         }
     }, [readingMode, readingDirection, pageFit, pageStretch, doublePageOffset])
 }

--- a/seanime-web/src/app/(main)/manga/_lib/handle-chapter-reader.ts
+++ b/seanime-web/src/app/(main)/manga/_lib/handle-chapter-reader.ts
@@ -390,6 +390,7 @@ export function useSwitchSettingsWithKeys() {
             mousetrap.unbind("f")
             mousetrap.unbind("s")
             mousetrap.unbind("=")
+            mousetrap.unbind("+")
             mousetrap.unbind("-")
         }
     }, [readingMode, readingDirection, pageFit, pageStretch, doublePageOffset])


### PR DESCRIPTION
This pull request added keyboard shortcut to increase or decrease the double pages offset. 

This is useful because the double page offset for manga is not consistent from one manga to the next or sometimes even within the same manga. 

I currently have the binding so that = and + increase the offset by 1 and - reduces the offset by 1. 