### PR TITLE
iOS urlencode workaround

### DIFF
--- a/seanime-web/src/app/(main)/_atoms/playback.atoms.tsx
+++ b/seanime-web/src/app/(main)/_atoms/playback.atoms.tsx
@@ -84,15 +84,18 @@ export function useCurrentDevicePlaybackSettings() {
 
 export const __playback_externalPlayerLink = atomWithStorage<string>("sea-playback-external-player-link", "")
 export const __playback_externalPlayerLink_encodePath = atomWithStorage<boolean>("sea-playback-external-player-link-encode-path", false)
-
+export const __playback_externalPlayerLink_urlencodePath = atomWithStorage<boolean>("sea-playback-external-player-link-urlencode-path", false)
 export function useExternalPlayerLink() {
     const [externalPlayerLink, setExternalPlayerLink] = useAtom(__playback_externalPlayerLink)
     const [encodePath, setEncodePath] = useAtom(__playback_externalPlayerLink_encodePath)
+    const [urlencodePath, setUrlencodePath] = useAtom(__playback_externalPlayerLink_urlencodePath)
     return {
         externalPlayerLink,
         setExternalPlayerLink,
         encodePath,
         setEncodePath,
+        urlencodePath,
+        setUrlencodePath,
     }
 }
 

--- a/seanime-web/src/app/(main)/medialinks/page.tsx
+++ b/seanime-web/src/app/(main)/medialinks/page.tsx
@@ -37,7 +37,7 @@ export default function Page() {
 
     const { mutate: startManualTracking, isPending: isStarting } = usePlaybackStartManualTracking()
 
-    const { externalPlayerLink, encodePath } = useExternalPlayerLink()
+    const { externalPlayerLink, encodePath, urlencodePath } = useExternalPlayerLink()
 
     function encodeFilePath(filePath: string) {
         if (encodePath) {
@@ -74,7 +74,10 @@ export default function Page() {
                 const tokenQueryParam = await getHMACTokenQueryParam("/api/v1/mediastream/file", "&")
 
                 // Send video to external player
-                const urlToSend = getServerBaseUrl() + endpoint + tokenQueryParam
+                let urlToSend = getServerBaseUrl() + endpoint + tokenQueryParam
+                if (urlencodePath) {
+                    urlToSend = encodeURIComponent(getServerBaseUrl() + endpoint + tokenQueryParam)
+                }
                 logger("MEDIALINKS").info("Opening external player", externalPlayerLink, "URL", urlToSend)
 
                 openTab(getExternalPlayerURL(externalPlayerLink, urlToSend))

--- a/seanime-web/src/app/(main)/settings/_components/mediaplayer-settings.tsx
+++ b/seanime-web/src/app/(main)/settings/_components/mediaplayer-settings.tsx
@@ -206,7 +206,7 @@ export function MediaplayerSettings(props: MediaplayerSettingsProps) {
 
 export function ExternalPlayerLinkSettings() {
 
-    const { externalPlayerLink, setExternalPlayerLink, encodePath, setEncodePath } = useExternalPlayerLink()
+    const { externalPlayerLink, setExternalPlayerLink, encodePath, setEncodePath, urlencodePath, setUrlencodePath } = useExternalPlayerLink()
 
     return (
         <>
@@ -239,6 +239,16 @@ export function ExternalPlayerLinkSettings() {
                     help="If enabled, the file path will be base64 encoded in the URL to avoid issues with special characters."
                     value={encodePath}
                     onValueChange={setEncodePath}
+                />
+            </SettingsCard>
+            <SettingsCard>
+                <Switch
+                    side="right"
+                    name="urlencodePath"
+                    label="urlencode {url} (library only)"
+                    help="If enabled, the {url} will be URL encoded to avoid issues with special characters when embeding as URI parameter usecase iOS/iPadOS"
+                    value={urlencodePath}
+                    onValueChange={setUrlencodePath}
                 />
             </SettingsCard>
 


### PR DESCRIPTION
Dirty fix for #387 requesting general feedback as you will see I have just reused structure of encodePath. Tested on iOS it does works with VLC. 