### PR TITLE
fix(vlc): resolve double URL encoding for HTTP URLs with tokens

### DIFF
--- a/internal/mediaplayers/vlc/status.go
+++ b/internal/mediaplayers/vlc/status.go
@@ -202,10 +202,17 @@ func (vlc *VLC) AddAndPlay(uri string, option ...string) error {
 	if len(option) > 1 {
 		return errors.New("please provide only one option")
 	}
-	urlSegment := "/requests/status.json?command=in_play&input=" + url.PathEscape(filepath.FromSlash(uri))
+	
+	var encodedInput string
 	if strings.HasPrefix(uri, "http") {
-		urlSegment = "/requests/status.json?command=in_play&input=" + url.PathEscape(uri)
+		// For HTTP URLs, use QueryEscape to preserve URL structure and query parameters
+		encodedInput = url.QueryEscape(uri)
+	} else {
+		// For file paths, use PathEscape
+		encodedInput = url.PathEscape(filepath.FromSlash(uri))
 	}
+	
+	urlSegment := "/requests/status.json?command=in_play&input=" + encodedInput
 	if len(option) == 1 {
 		if (option[0] != "noaudio") && (option[0] != "novideo") {
 			return errors.New("invalid option")
@@ -218,13 +225,29 @@ func (vlc *VLC) AddAndPlay(uri string, option ...string) error {
 
 // Add adds a URI to the playlist
 func (vlc *VLC) Add(uri string) (err error) {
-	_, err = vlc.RequestMaker("/requests/status.json?command=in_enqueue&input=" + url.PathEscape(uri))
+	var encodedInput string
+	if strings.HasPrefix(uri, "http") {
+		// For HTTP URLs, use QueryEscape to preserve URL structure and query parameters
+		encodedInput = url.QueryEscape(uri)
+	} else {
+		// For file paths, use PathEscape
+		encodedInput = url.PathEscape(uri)
+	}
+	_, err = vlc.RequestMaker("/requests/status.json?command=in_enqueue&input=" + encodedInput)
 	return
 }
 
 // AddSubtitle adds a subtitle from URI to currently playing file
 func (vlc *VLC) AddSubtitle(uri string) (err error) {
-	_, err = vlc.RequestMaker("/requests/status.json?command=addsubtitle&val=" + url.PathEscape(uri))
+	var encodedInput string
+	if strings.HasPrefix(uri, "http") {
+		// For HTTP URLs, use QueryEscape to preserve URL structure and query parameters
+		encodedInput = url.QueryEscape(uri)
+	} else {
+		// For file paths, use PathEscape
+		encodedInput = url.PathEscape(uri)
+	}
+	_, err = vlc.RequestMaker("/requests/status.json?command=addsubtitle&val=" + encodedInput)
 	return
 }
 


### PR DESCRIPTION
🔧 **VLC External Player URL Encoding Fix**

**Fixed Double-Encoding Issue in VLC HTTP Interface**

The VLC external player was experiencing token corruption when streaming URLs containing authentication tokens, particularly affecting TorBox downloads. The root cause was double URL encoding - once during external player link formatting and again in VLC's HTTP interface methods.

**What Changed:**
- Modified `AddAndPlay()` method in `status.go` to use conditional URL encoding
- Updated `Add()` method with the same conditional logic
- Fixed `AddSubtitle()` method to prevent similar encoding issues

**Technical Details:**
- **For HTTP URLs**: Now uses `url.QueryEscape()` to preserve URL structure and query parameters
- **For File Paths**: Continues using `url.PathEscape()` for proper file system path handling
- **Conditional Logic**: `strings.HasPrefix(uri, "http")` determines encoding method

**Why This Matters:**
VLC communicates via its HTTP interface (`/requests/status.json?command=in_play&input=`), where the stream URL becomes a query parameter. Previously, tokens were being double-encoded:
1. First encoding during external player link generation
2. Second encoding via `url.PathEscape()` in VLC methods

**Real-World Impact – TorBox Integration**  
TorBox URLs were being corrupted by double-encoding, which broke the query-parameter structure and stripped the token value, resulting in “Invalid Authorization Token” errors.

- **Before the fix:**  
  Original URL → `…?token=TORBOX_API_KEY`  
  After double-encoding → `…%3Ftoken%3DTORBOX_API_KEY`  
  TorBox received only `…?token`, without the key.

- **After the fix:**  
  The URL is now preserved correctly, ensuring the full token is delivered to TorBox.

**Impact:**
- ✅ VLC now correctly receives and processes stream URLs with authentication tokens
- ✅ TorBox downloads work properly without "Invalid Authorization Token" errors (HTTP 401 in VLC)
- ✅ Token parameter values are preserved in the URL query string
- ✅ Maintains backward compatibility for local file playback
- ✅ Consistent URL handling across all VLC methods (`AddAndPlay`, `Add`, `AddSubtitle`)
