### PR TITLE
fix toDebridTorrentStatus by removing 'uploading' case

### DIFF
--- a/internal/debrid/torbox/torbox.go
+++ b/internal/debrid/torbox/torbox.go
@@ -577,7 +577,6 @@ func toDebridTorrentInfo(t *TorrentInfo) (ret *debrid.TorrentInfo) {
 
 	return
 }
-
 func toDebridTorrentStatus(t *Torrent) debrid.TorrentItemStatus {
 	if t.DownloadFinished && t.DownloadPresent {
 		switch t.DownloadState {
@@ -595,8 +594,6 @@ func toDebridTorrentStatus(t *Torrent) debrid.TorrentItemStatus {
 		return debrid.TorrentItemStatusStalled
 	case "completed", "cached":
 		return debrid.TorrentItemStatusCompleted
-	case "uploading":
-		return debrid.TorrentItemStatusSeeding
 	case "paused":
 		return debrid.TorrentItemStatusPaused
 	default:


### PR DESCRIPTION
Issue: In the debrid tab some animes show as seeding even though they're not
Fix: modified the status logic to only return "Seeding" status for torrents that are both finished downloading AND in the "uploading" state. Incomplete torrents in the "uploading" state now correctly fall through to the default case and return `TorrentItemStatusOther`.