### PR TITLE
Auto Downloader Batch rules, toggle to list/filter only airing or soon be aired shows

### DIFF
--- a/seanime-web/src/app/(main)/auto-downloader/_containers/autodownloader-batch-rule-form.tsx
+++ b/seanime-web/src/app/(main)/auto-downloader/_containers/autodownloader-batch-rule-form.tsx
@@ -11,6 +11,7 @@ import { useServerStatus } from "@/app/(main)/_hooks/use-server-status"
 import { TextArrayField } from "@/app/(main)/auto-downloader/_containers/autodownloader-rule-form"
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
 import { CloseButton, IconButton } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Combobox } from "@/components/ui/combobox"
 import { cn } from "@/components/ui/core/styling"
 import { defineSchema, Field, Form, InferType } from "@/components/ui/form"
@@ -111,27 +112,14 @@ export function AutoDownloaderBatchRuleForm(props: AutoDownloaderBatchRuleFormPr
             >
                 {(f) => (
                     <div className="space-y-4">
-                        <div className="flex items-center gap-2">
-                            <div className="flex-1"></div>
-                            <div className="flex items-center gap-2 text-sm">
-                                <label htmlFor="show-releasing-only-batch" className="cursor-pointer">
-                                    Hide finished
-                                </label>
-                                <input
-                                    type="checkbox"
-                                    id="show-releasing-only-batch"
-                                    className="size-4"
-                                    checked={showReleasingOnly}
-                                    onChange={e => setShowReleasingOnly(e.target.checked)}
-                                />
-                            </div>
-                        </div>
                         <RuleFormFields
                             form={f}
                             allMedia={allMedia}
                             isPending={isPending}
                             notFinishedMedia={notFinishedMedia}
                             libraryCollection={libraryCollection}
+                            hideFinished={showReleasingOnly}
+                            toggleHideFinished={() => setShowReleasingOnly((prev) => !prev)}
                         />
                     </div>
                 )}
@@ -146,6 +134,8 @@ type RuleFormFieldsProps = {
     isPending: boolean
     notFinishedMedia: AL_BaseAnime[]
     libraryCollection?: Anime_LibraryCollection | undefined
+    hideFinished: boolean
+    toggleHideFinished: () => void
 }
 
 function RuleFormFields(props: RuleFormFieldsProps) {
@@ -156,6 +146,8 @@ function RuleFormFields(props: RuleFormFieldsProps) {
         isPending,
         notFinishedMedia,
         libraryCollection,
+        hideFinished,
+        toggleHideFinished,
         ...rest
     } = props
 
@@ -163,7 +155,19 @@ function RuleFormFields(props: RuleFormFieldsProps) {
 
     return (
         <>
-            <Field.Switch name="enabled" label="Enabled" />
+            <div className="flex flex-col gap-2 md:flex-row justify-between items-center">
+                <Field.Switch name="enabled" label="Enabled" />
+                <div className="flex items-center gap-2">
+                    <label htmlFor="show-releasing-only-batch" className="cursor-pointer text-sm">
+                        Hide finished
+                    </label>
+                    <Checkbox
+                        id="show-releasing-only-batch"
+                        value={hideFinished}
+                        onValueChange={() => toggleHideFinished()}
+                    />
+                </div>
+            </div>
             <Separator />
             <div
                 className={cn(

--- a/seanime-web/src/app/(main)/auto-downloader/_containers/autodownloader-batch-rule-form.tsx
+++ b/seanime-web/src/app/(main)/auto-downloader/_containers/autodownloader-batch-rule-form.tsx
@@ -58,10 +58,14 @@ export function AutoDownloaderBatchRuleForm(props: AutoDownloaderBatchRuleFormPr
         return userMedia ?? []
     }, [userMedia])
 
+    const [showReleasingOnly, setShowReleasingOnly] = React.useState(true)
+
     const notFinishedMedia = React.useMemo(() => {
-        // return allMedia.filter(media => media.status !== "FINISHED")
+        if (showReleasingOnly) {
+            return allMedia.filter(media => media.status !== "FINISHED")
+        }
         return allMedia
-    }, [allMedia])
+    }, [allMedia, showReleasingOnly])
 
     const { mutate: createRule, isPending: creatingRule } = useCreateAutoDownloaderRule()
 
@@ -105,13 +109,32 @@ export function AutoDownloaderBatchRuleForm(props: AutoDownloaderBatchRuleFormPr
                     titleComparisonType: "likely",
                 }}
             >
-                {(f) => <RuleFormFields
-                    form={f}
-                    allMedia={allMedia}
-                    isPending={isPending}
-                    notFinishedMedia={notFinishedMedia}
-                    libraryCollection={libraryCollection}
-                />}
+                {(f) => (
+                    <div className="space-y-4">
+                        <div className="flex items-center gap-2">
+                            <div className="flex-1"></div>
+                            <div className="flex items-center gap-2 text-sm">
+                                <label htmlFor="show-releasing-only-batch" className="cursor-pointer">
+                                    Hide finished
+                                </label>
+                                <input
+                                    type="checkbox"
+                                    id="show-releasing-only-batch"
+                                    className="size-4"
+                                    checked={showReleasingOnly}
+                                    onChange={e => setShowReleasingOnly(e.target.checked)}
+                                />
+                            </div>
+                        </div>
+                        <RuleFormFields
+                            form={f}
+                            allMedia={allMedia}
+                            isPending={isPending}
+                            notFinishedMedia={notFinishedMedia}
+                            libraryCollection={libraryCollection}
+                        />
+                    </div>
+                )}
             </Form>
         </div>
     )
@@ -169,7 +192,7 @@ function RuleFormFields(props: RuleFormFieldsProps) {
                                 label: <div className="w-full">
                                     <p className="mb-1 flex items-center"><MdVerified className="text-lg inline-block mr-2" />Most likely</p>
                                     <p className="font-normal text-sm text-[--muted]">The torrent name will be parsed and analyzed using a comparison
-                                                                                      algorithm</p>
+                                        algorithm</p>
                                 </div>,
                                 value: "likely",
                             },
@@ -177,7 +200,7 @@ function RuleFormFields(props: RuleFormFieldsProps) {
                                 label: <div className="w-full">
                                     <p className="mb-1 flex items-center"><LuTextCursorInput className="text-lg inline-block mr-2" />Exact match</p>
                                     <p className="font-normal text-sm text-[--muted]">The torrent name must contain the comparison title you set (case
-                                                                                      insensitive)</p>
+                                        insensitive)</p>
                                 </div>,
                                 value: "contains",
                             },
@@ -223,19 +246,19 @@ function RuleFormFields(props: RuleFormFieldsProps) {
                         <AccordionContent className="pt-0">
                             <div className="border rounded-[--radius] p-4 relative !mt-8 space-y-3">
                                 <div className="absolute -top-2.5 tracking-wide font-semibold uppercase text-sm left-4 bg-gray-950 px-2">Additional
-                                                                                                                                         terms
+                                    terms
                                 </div>
                                 <div>
                                     <p className="text-sm -top-2 relative"><span className="text-red-100">
                                         All options must be included for the torrent to be accepted.</span> Within each option, you can
-                                                                                                            include variations separated by
-                                                                                                            commas. For example, adding
-                                                                                                            "H265,H.265, H 265,x265" and
-                                                                                                            "10bit,10-bit,10 bit" will match
+                                        include variations separated by
+                                        commas. For example, adding
+                                        "H265,H.265, H 265,x265" and
+                                        "10bit,10-bit,10 bit" will match
                                         <code className="text-gray-400"> [Group] Torrent name [HEVC 10bit
-                                                                         x265]</code> but not <code className="text-gray-400">[Group] Torrent name
-                                                                                                                              [H265]</code>. Case
-                                                                                                            insensitive.</p>
+                                            x265]</code> but not <code className="text-gray-400">[Group] Torrent name
+                                                [H265]</code>. Case
+                                        insensitive.</p>
                                 </div>
 
                                 <TextArrayField
@@ -345,22 +368,22 @@ export function MediaArrayField(props: MediaArrayFieldProps) {
                                     <Combobox
                                         label="Library Entry"
                                         options={props.allMedia.map(media => ({
-                                                label: <div className="flex items-center gap-2">
-                                                    <div className="size-10 rounded-full bg-gray-800 flex items-center justify-center relative overflow-hidden flex-none">
-                                                        <Image
-                                                            src={media.coverImage?.medium ?? "/no-cover.png"}
-                                                            alt="cover"
-                                                            sizes="2rem"
-                                                            fill
-                                                            className="object-cover object-center"
-                                                        />
-                                                    </div>
-                                                    <p>{media.title?.userPreferred || "N/A"}</p>
-                                                    <p className="text-[--muted] text-sm">{capitalize(media.status)?.replaceAll("_", " ")}</p>
-                                                </div>,
-                                                value: String(media.id),
-                                                textValue: media.title?.userPreferred || "N/A",
-                                            }))
+                                            label: <div className="flex items-center gap-2">
+                                                <div className="size-10 rounded-full bg-gray-800 flex items-center justify-center relative overflow-hidden flex-none">
+                                                    <Image
+                                                        src={media.coverImage?.medium ?? "/no-cover.png"}
+                                                        alt="cover"
+                                                        sizes="2rem"
+                                                        fill
+                                                        className="object-cover object-center"
+                                                    />
+                                                </div>
+                                                <p>{media.title?.userPreferred || "N/A"}</p>
+                                                <p className="text-[--muted] text-sm">{capitalize(media.status)?.replaceAll("_", " ")}</p>
+                                            </div>,
+                                            value: String(media.id),
+                                            textValue: media.title?.userPreferred || "N/A",
+                                        }))
                                             .toSorted((a, b) => a.textValue.localeCompare(b.textValue))}
                                         value={[String(field.mediaId)]}
                                         onValueChange={(v) => handleFieldChange(index,

--- a/seanime-web/src/app/(main)/auto-downloader/_containers/autodownloader-rule-form.tsx
+++ b/seanime-web/src/app/(main)/auto-downloader/_containers/autodownloader-rule-form.tsx
@@ -174,6 +174,7 @@ type RuleFormFieldsProps = {
 
     hideFinished?: boolean
     toggleHideFinished?: () => void
+    rule?: Anime_AutoDownloaderRule
 }
 
 export function RuleFormFields(props: RuleFormFieldsProps) {

--- a/seanime-web/src/app/(main)/auto-downloader/_containers/autodownloader-rule-form.tsx
+++ b/seanime-web/src/app/(main)/auto-downloader/_containers/autodownloader-rule-form.tsx
@@ -64,11 +64,14 @@ export function AutoDownloaderRuleForm(props: AutoDownloaderRuleFormProps) {
         return userMedia ?? []
     }, [userMedia])
 
+    const [showReleasingOnly, setShowReleasingOnly] = React.useState(true)
+
     const notFinishedMedia = React.useMemo(() => {
-        // return allMedia.filter(media => media.status !== "FINISHED")
-        // Note: return all
+        if (showReleasingOnly) {
+            return allMedia.filter(media => media.status !== "FINISHED")
+        }
         return allMedia
-    }, [allMedia])
+    }, [allMedia, showReleasingOnly])
 
     const { mutate: createRule, isPending: creatingRule } = useCreateAutoDownloaderRule()
 
@@ -130,16 +133,37 @@ export function AutoDownloaderRuleForm(props: AutoDownloaderRuleFormProps) {
                     toast.error("An error occurred, verify the fields.")
                 }}
             >
-                {(f) => <RuleFormFields
-                    form={f}
-                    allMedia={allMedia}
-                    mediaId={mediaId}
-                    type={type}
-                    isPending={isPending}
-                    notFinishedMedia={notFinishedMedia}
-                    libraryCollection={libraryCollection}
-                    rule={rule}
-                />}
+                {(f) => (
+                    <div className="space-y-4">
+                        {(!mediaId) && (
+                            <div className="flex items-center gap-2">
+                                <div className="flex-1"></div>
+                                <div className="flex items-center gap-2 text-sm">
+                                    <label htmlFor="show-releasing-only" className="cursor-pointer">
+                                        Hide finished
+                                    </label>
+                                    <input
+                                        type="checkbox"
+                                        id="show-releasing-only"
+                                        className="size-4"
+                                        checked={showReleasingOnly}
+                                        onChange={e => setShowReleasingOnly(e.target.checked)}
+                                    />
+                                </div>
+                            </div>
+                        )}
+                        <RuleFormFields
+                            form={f}
+                            allMedia={allMedia}
+                            mediaId={mediaId}
+                            type={type}
+                            isPending={isPending}
+                            notFinishedMedia={notFinishedMedia}
+                            libraryCollection={libraryCollection}
+                            rule={rule}
+                        />
+                    </div>
+                )}
             </Form>
             {type === "edit" && <DangerZone
                 actionText="Delete this rule"
@@ -242,22 +266,22 @@ export function RuleFormFields(props: RuleFormFieldsProps) {
                         name="mediaId"
                         label="Library Entry"
                         options={notFinishedMedia.map(media => ({
-                                label: <div className="flex items-center gap-2">
-                                    <div className="size-10 rounded-full bg-gray-800 flex items-center justify-center relative overflow-hidden flex-none">
-                                        <Image
-                                            src={media.coverImage?.medium ?? "/no-cover.png"}
-                                            alt="cover"
-                                            sizes="2rem"
-                                            fill
-                                            className="object-cover object-center"
-                                        />
-                                    </div>
-                                    <p>{media.title?.userPreferred || "N/A"}</p>
-                                    <p className="text-[--muted] text-sm">{capitalize(media.status)?.replaceAll("_", " ")}</p>
-                                </div>,
-                                value: String(media.id),
-                                textValue: media.title?.userPreferred || "N/A",
-                            }))
+                            label: <div className="flex items-center gap-2">
+                                <div className="size-10 rounded-full bg-gray-800 flex items-center justify-center relative overflow-hidden flex-none">
+                                    <Image
+                                        src={media.coverImage?.medium ?? "/no-cover.png"}
+                                        alt="cover"
+                                        sizes="2rem"
+                                        fill
+                                        className="object-cover object-center"
+                                    />
+                                </div>
+                                <p>{media.title?.userPreferred || "N/A"}</p>
+                                <p className="text-[--muted] text-sm">{capitalize(media.status)?.replaceAll("_", " ")}</p>
+                            </div>,
+                            value: String(media.id),
+                            textValue: media.title?.userPreferred || "N/A",
+                        }))
                             .toSorted((a, b) => a.textValue.localeCompare(b.textValue))}
                         value={[String(form_mediaId)]}
                         onValueChange={(v) => form.setValue("mediaId", v[0] ? parseInt(v[0]) : notFinishedMedia[0]?.id)}
@@ -292,7 +316,7 @@ export function RuleFormFields(props: RuleFormFieldsProps) {
                                 label: <div className="w-full">
                                     <p className="mb-1 flex items-center"><MdVerified className="text-lg inline-block mr-2" />Most likely</p>
                                     <p className="font-normal text-sm text-[--muted]">The torrent name will be parsed and analyzed using a comparison
-                                                                                      algorithm</p>
+                                        algorithm</p>
                                 </div>,
                                 value: "likely",
                             },
@@ -300,7 +324,7 @@ export function RuleFormFields(props: RuleFormFieldsProps) {
                                 label: <div className="w-full">
                                     <p className="mb-1 flex items-center"><LuTextCursorInput className="text-lg inline-block mr-2" />Exact match</p>
                                     <p className="font-normal text-sm text-[--muted]">The torrent name must contain the comparison title you set (case
-                                                                                      insensitive)</p>
+                                        insensitive)</p>
                                 </div>,
                                 value: "contains",
                             },
@@ -381,7 +405,7 @@ export function RuleFormFields(props: RuleFormFieldsProps) {
                         <AccordionContent className="pt-0">
                             <div className="border rounded-[--radius] p-4 relative !mt-8 space-y-3">
                                 <div className="absolute -top-2.5 tracking-wide font-semibold uppercase text-sm left-4 bg-gray-950 px-2">Additional
-                                                                                                                                         terms
+                                    terms
                                 </div>
                                 <div>
                                     {/*<p className="text-sm">*/}
@@ -389,14 +413,14 @@ export function RuleFormFields(props: RuleFormFieldsProps) {
                                     {/*</p>*/}
                                     <p className="text-sm -top-2 relative"><span className="text-red-100">
                                         All options must be included for the torrent to be accepted.</span> Within each option, you can
-                                                                                                            include variations separated by
-                                                                                                            commas. For example, adding
-                                                                                                            "H265,H.265, H 265,x265" and
-                                                                                                            "10bit,10-bit,10 bit" will match
+                                        include variations separated by
+                                        commas. For example, adding
+                                        "H265,H.265, H 265,x265" and
+                                        "10bit,10-bit,10 bit" will match
                                         <code className="text-gray-400"> [Group] Torrent name [HEVC 10bit
-                                                                         x265]</code> but not <code className="text-gray-400">[Group] Torrent name
-                                                                                                                              [H265]</code>. Case
-                                                                                                            insensitive.</p>
+                                            x265]</code> but not <code className="text-gray-400">[Group] Torrent name
+                                                [H265]</code>. Case
+                                        insensitive.</p>
                                 </div>
 
                                 <TextArrayField

--- a/seanime-web/src/app/(main)/auto-downloader/_containers/autodownloader-rule-form.tsx
+++ b/seanime-web/src/app/(main)/auto-downloader/_containers/autodownloader-rule-form.tsx
@@ -11,6 +11,7 @@ import { useLibraryCollection } from "@/app/(main)/_hooks/anime-library-collecti
 import { useServerStatus } from "@/app/(main)/_hooks/use-server-status"
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
 import { CloseButton, IconButton } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Combobox } from "@/components/ui/combobox"
 import { cn } from "@/components/ui/core/styling"
 import { DangerZone, defineSchema, Field, Form, InferType } from "@/components/ui/form"
@@ -135,23 +136,6 @@ export function AutoDownloaderRuleForm(props: AutoDownloaderRuleFormProps) {
             >
                 {(f) => (
                     <div className="space-y-4">
-                        {(!mediaId) && (
-                            <div className="flex items-center gap-2">
-                                <div className="flex-1"></div>
-                                <div className="flex items-center gap-2 text-sm">
-                                    <label htmlFor="show-releasing-only" className="cursor-pointer">
-                                        Hide finished
-                                    </label>
-                                    <input
-                                        type="checkbox"
-                                        id="show-releasing-only"
-                                        className="size-4"
-                                        checked={showReleasingOnly}
-                                        onChange={e => setShowReleasingOnly(e.target.checked)}
-                                    />
-                                </div>
-                            </div>
-                        )}
                         <RuleFormFields
                             form={f}
                             allMedia={allMedia}
@@ -161,6 +145,8 @@ export function AutoDownloaderRuleForm(props: AutoDownloaderRuleFormProps) {
                             notFinishedMedia={notFinishedMedia}
                             libraryCollection={libraryCollection}
                             rule={rule}
+                            hideFinished={showReleasingOnly}
+                            toggleHideFinished={() => setShowReleasingOnly((prev) => !prev)}
                         />
                     </div>
                 )}
@@ -185,7 +171,9 @@ type RuleFormFieldsProps = {
     isPending: boolean
     notFinishedMedia: AL_BaseAnime[]
     libraryCollection?: Anime_LibraryCollection | undefined
-    rule?: Anime_AutoDownloaderRule
+
+    hideFinished?: boolean
+    toggleHideFinished?: () => void
 }
 
 export function RuleFormFields(props: RuleFormFieldsProps) {
@@ -199,6 +187,8 @@ export function RuleFormFields(props: RuleFormFieldsProps) {
         notFinishedMedia,
         libraryCollection,
         rule,
+        hideFinished,
+        toggleHideFinished,
         ...rest
     } = props
 
@@ -240,7 +230,21 @@ export function RuleFormFields(props: RuleFormFieldsProps) {
 
     return (
         <>
-            <Field.Switch name="enabled" label="Enabled" />
+            <div className="flex flex-col gap-2 md:flex-row justify-between items-center">
+                <Field.Switch name="enabled" label="Enabled" />
+                {((toggleHideFinished !== undefined && hideFinished !== undefined) && !mediaId) && (
+                    <div className="flex items-center gap-2">
+                        <label htmlFor="show-releasing-only" className="cursor-pointer text-sm">
+                            Hide finished
+                        </label>
+                        <Checkbox
+                            id="show-releasing-only"
+                            value={hideFinished}
+                            onValueChange={() => toggleHideFinished()}
+                        />
+                    </div>
+                )}
+            </div>
             <Separator />
             <div
                 className={cn(


### PR DESCRIPTION
Fixes https://github.com/5rahim/seanime/issues/573
AI assisted

This update introduces a "Hide finished" toggle to the Auto Downloader rule forms, streamlining the selection process by allowing users to filter out completed anime.

Changes
Auto Downloader Rule Forms: Added a checkbox to toggle visibility of finished anime in the selection list.
UI Integration: The toggle is now integrated into the RuleFormFields component, placing it alongside the "Enabled" switch 
