### PR TITLE
Hide/show denshi with system tray icon

### DIFF
--- a/seanime-denshi/src/main.js
+++ b/seanime-denshi/src/main.js
@@ -450,10 +450,18 @@ function createTray() {
     tray.setContextMenu(contextMenu)
 
     tray.on("click", () => {
-        mainWindow.show()
-        mainWindow.focus()
-        if (process.platform === "darwin") {
-            app.dock.show()
+        if(mainWindow.isVisible()) {
+            mainWindow.hide()
+            if (process.platform === "darwin") {
+                app.dock.hide();
+            }
+        }
+        else {
+            mainWindow.show()
+            mainWindow.focus()
+            if (process.platform === "darwin") {
+                app.dock.show()
+            }
         }
     })
 }


### PR DESCRIPTION
Currently denshi can only show main window when you click on system tray icon but most apps can as well hide main window if it is already visible