### PR TITLE
Remove the 4 year filter for batches

### DIFF
--- a/internal/torrents/autoselect/search.go
+++ b/internal/torrents/autoselect/search.go
@@ -247,12 +247,7 @@ func (s *AutoSelect) searchFromProvider(
 
 // shouldSearchBatch determines if we should initially attempt to search for batches.
 func (s *AutoSelect) shouldSearchBatch(media *anilist.CompleteAnime) bool {
-	// Search batch if not a movie and finished
-	yearsSinceStart := 999
-	if media.StartDate != nil && *media.StartDate.Year > 0 {
-		yearsSinceStart = time.Now().Year() - *media.StartDate.Year
-	}
-	if !media.IsMovie() && media.IsFinished()  {
+	if !media.IsMovie() && media.IsFinished() {
 		return true
 	}
 	return false

--- a/internal/torrents/autoselect/search.go
+++ b/internal/torrents/autoselect/search.go
@@ -252,7 +252,7 @@ func (s *AutoSelect) shouldSearchBatch(media *anilist.CompleteAnime) bool {
 	if media.StartDate != nil && *media.StartDate.Year > 0 {
 		yearsSinceStart = time.Now().Year() - *media.StartDate.Year
 	}
-	if !media.IsMovie() && media.IsFinished() && yearsSinceStart > 4 {
+	if !media.IsMovie() && media.IsFinished()  {
 		return true
 	}
 	return false


### PR DESCRIPTION
Hi, i had issues with a couple series not selecting batches. Even though the series was finished and seanime not being able to find individual episodes causing it to not be able to find anything. This will at least make batches auto selectable, i believe this was initially added cause batches usually took a while to get added (?) but i believe they are created almost instantly now.

<img width="536" height="258" alt="screenshot_20260207_095232" src="https://github.com/user-attachments/assets/9dad5df2-5f06-4e9f-bc0f-e0ccbea422d1" />
