### PR TITLE
feat: add custom subtitle delay controls with incremental buttons

### DIFF
--- a/seanime-web/src/app/(main)/_features/video-core/video-core-preferences.tsx
+++ b/seanime-web/src/app/(main)/_features/video-core/video-core-preferences.tsx
@@ -605,6 +605,20 @@ export function VideoCorePreferencesModal({ isWebPlayer }: { isWebPlayer: boolea
                                 help="Subtitle tracks that will not be selected by default if they match the preferred lanauges. Separate multiple names with commas."
                             />
                         </div>
+                        <div className="space-y-2">
+                            <label className="text-sm font-medium text-muted-foreground">
+                                Default Subtitle Delay (seconds)
+                            </label>
+                            <NumberInput
+                                value={editedSubtitleDelay}
+                                onValueChange={(v) => setEditedSubtitleDelay(v ?? 0)}
+                                step={0.1}
+                                placeholder="0"
+                                onKeyDown={(e) => e.stopPropagation()}
+                                onInput={(e) => e.stopPropagation()}
+                                help="Positive values delay subtitles, negative values advance them. This value is applied when the player starts."
+                            />
+                        </div>
                     </div>
 
                     {isWebPlayer && <div className="space-y-3">

--- a/seanime-web/src/app/(main)/_features/video-core/video-core-preferences.tsx
+++ b/seanime-web/src/app/(main)/_features/video-core/video-core-preferences.tsx
@@ -609,15 +609,44 @@ export function VideoCorePreferencesModal({ isWebPlayer }: { isWebPlayer: boolea
                             <label className="text-sm font-medium text-muted-foreground">
                                 Default Subtitle Delay (seconds)
                             </label>
-                            <NumberInput
-                                value={editedSubtitleDelay}
-                                onValueChange={(v) => setEditedSubtitleDelay(v ?? 0)}
-                                step={0.1}
-                                placeholder="0"
-                                onKeyDown={(e) => e.stopPropagation()}
-                                onInput={(e) => e.stopPropagation()}
-                                help="Positive values delay subtitles, negative values advance them. This value is applied when the player starts."
-                            />
+                            <p className="text-xs text-muted-foreground">Positive values delay subtitles, negative values advance them.</p>
+                            <div className="flex gap-1.5 items-center">
+                                <Button
+                                    intent="gray-glass"
+                                    size="sm"
+                                    className="flex-1 font-bold text-base"
+                                    onClick={() => setEditedSubtitleDelay(v => parseFloat((v - 0.5).toFixed(1)))}
+                                >
+                                    −0.5
+                                </Button>
+                                <Button
+                                    intent="gray-glass"
+                                    size="sm"
+                                    className="flex-1 text-sm"
+                                    onClick={() => setEditedSubtitleDelay(v => parseFloat((v - 0.1).toFixed(1)))}
+                                >
+                                    −0.1
+                                </Button>
+                                <span className="text-sm text-muted-foreground px-2 tabular-nums shrink-0 min-w-[3.5rem] text-center">
+                                    {editedSubtitleDelay.toFixed(1)}s
+                                </span>
+                                <Button
+                                    intent="gray-glass"
+                                    size="sm"
+                                    className="flex-1 text-sm"
+                                    onClick={() => setEditedSubtitleDelay(v => parseFloat((v + 0.1).toFixed(1)))}
+                                >
+                                    +0.1
+                                </Button>
+                                <Button
+                                    intent="gray-glass"
+                                    size="sm"
+                                    className="flex-1 font-bold text-base"
+                                    onClick={() => setEditedSubtitleDelay(v => parseFloat((v + 0.5).toFixed(1)))}
+                                >
+                                    +0.5
+                                </Button>
+                            </div>
                         </div>
                     </div>
 

--- a/seanime-web/src/app/(main)/_features/video-core/video-core-settings-menu.tsx
+++ b/seanime-web/src/app/(main)/_features/video-core/video-core-settings-menu.tsx
@@ -489,6 +489,20 @@ export function VideoCoreSettingsMenu() {
                             }}
                             value={editedSubtitleDelay}
                         />
+                        <p className="text-sm text-[--muted] mt-3 mb-1">Custom value (seconds)</p>
+                        <div className="flex gap-2 items-center">
+                            <input
+                                type="number"
+                                step="0.1"
+                                className="w-full bg-transparent border border-[--border] rounded-md px-2 py-1 text-sm text-white focus:outline-none focus:border-[--ring]"
+                                value={editedSubtitleDelay}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    const v = parseFloat(e.target.value)
+                                    if (!isNaN(v)) handleSubtitleDelayChange(v)
+                                }}
+                            />
+                            <span className="text-sm text-[--muted] shrink-0">s</span>
+                        </div>
                     </VideoCoreMenuOption>
                     <VideoCoreMenuOption title="Playback Speed" icon={MdSpeed}>
                         <VideoCoreSettingSelect

--- a/seanime-web/src/app/(main)/_features/video-core/video-core-settings-menu.tsx
+++ b/seanime-web/src/app/(main)/_features/video-core/video-core-settings-menu.tsx
@@ -487,21 +487,36 @@ export function VideoCoreSettingsMenu() {
                             onValueChange={(v: number) => {
                                 handleSubtitleDelayChange(v)
                             }}
-                            value={editedSubtitleDelay}
+                            value={[-2.0,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,2.0].includes(editedSubtitleDelay) ? editedSubtitleDelay : null}
                         />
-                        <p className="text-sm text-[--muted] mt-3 mb-1">Custom value (seconds)</p>
-                        <div className="flex gap-2 items-center">
-                            <input
-                                type="number"
-                                step="0.1"
-                                className="w-full bg-transparent border border-[--border] rounded-md px-2 py-1 text-sm text-white focus:outline-none focus:border-[--ring]"
-                                value={editedSubtitleDelay}
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                    const v = parseFloat(e.target.value)
-                                    if (!isNaN(v)) handleSubtitleDelayChange(v)
-                                }}
-                            />
-                            <span className="text-sm text-[--muted] shrink-0">s</span>
+                        <div className="flex gap-1.5 items-center mt-3">
+                            <button
+                                className="flex-1 py-1.5 rounded-md bg-white/10 hover:bg-white/20 active:bg-white/30 transition-colors text-white font-bold text-base"
+                                onClick={() => handleSubtitleDelayChange(parseFloat((editedSubtitleDelay - 0.5).toFixed(1)))}
+                            >
+                                −0.5
+                            </button>
+                            <button
+                                className="flex-1 py-1.5 rounded-md bg-white/10 hover:bg-white/20 active:bg-white/30 transition-colors text-white font-medium text-sm"
+                                onClick={() => handleSubtitleDelayChange(parseFloat((editedSubtitleDelay - 0.1).toFixed(1)))}
+                            >
+                                −0.1
+                            </button>
+                            <span className="text-sm text-[--muted] px-1 tabular-nums shrink-0 min-w-[3.5rem] text-center">
+                                {editedSubtitleDelay.toFixed(1)}s
+                            </span>
+                            <button
+                                className="flex-1 py-1.5 rounded-md bg-white/10 hover:bg-white/20 active:bg-white/30 transition-colors text-white font-medium text-sm"
+                                onClick={() => handleSubtitleDelayChange(parseFloat((editedSubtitleDelay + 0.1).toFixed(1)))}
+                            >
+                                +0.1
+                            </button>
+                            <button
+                                className="flex-1 py-1.5 rounded-md bg-white/10 hover:bg-white/20 active:bg-white/30 transition-colors text-white font-bold text-base"
+                                onClick={() => handleSubtitleDelayChange(parseFloat((editedSubtitleDelay + 0.5).toFixed(1)))}
+                            >
+                                +0.5
+                            </button>
                         </div>
                     </VideoCoreMenuOption>
                     <VideoCoreMenuOption title="Playback Speed" icon={MdSpeed}>


### PR DESCRIPTION
## Summary
Adds incremental subtitle delay controls to the video player, allowing users to adjust delay beyond the fixed ±2s preset range.

## Changes
- **In-player settings menu**: Added four buttons (−0.5s, −0.1s, +0.1s, +0.5s) below the preset select. The preset select deselects automatically when a custom value is applied.
- **Preferences modal (Subtitles tab)**: Same button controls for setting a default subtitle delay that persists across sessions.

## Motivation
The existing preset select only covers −2.0s to +2.0s in fixed steps. Users with sync issues outside this range had no way to compensate.