### PR TITLE
fix: initialize hydrationRules

### DIFF
--- a/internal/library/scanner/hydrator.go
+++ b/internal/library/scanner/hydrator.go
@@ -726,6 +726,10 @@ func (fh *FileHydrator) precompileRules() {
 			}
 		}
 
+		if fh.hydrationRules == nil {
+			fh.hydrationRules = make(map[string]*compiledHydrationRule)
+		}
+
 		fh.hydrationRules[rule.Pattern] = r
 	}
 }

--- a/internal/library/scanner/hydrator_test.go
+++ b/internal/library/scanner/hydrator_test.go
@@ -708,7 +708,6 @@ func TestFileHydrator_applyHydrationRule(t *testing.T) {
 				Logger:            logger,
 				ScanSummaryLogger: scanSummaryLogger,
 				Config:            config,
-				hydrationRules:    make(map[string]*compiledHydrationRule),
 			}
 
 			// Precompile the rules


### PR DESCRIPTION
Related to https://github.com/5rahim/seanime/pull/632

It is the same fix as with the `matchingRules` map there - it wasn't properly initialized before the assignment. The tests were passing because the map was initialized inside the test itself.