### PR TITLE
feat: add Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,11 @@
             };
           };
 
+          icon = pkgs.fetchurl {
+            url = "https://raw.githubusercontent.com/5rahim/seanime/main/docs/images/seanime-logo.png";
+            hash = "sha256-mS/HV4R52RnausdmEWWY5nuNgqmPSq2+cw1xHnuAOhY=";
+          };
+
           seanime-denshi = pkgs.appimageTools.wrapType2 {
             pname = "seanime-denshi";
             inherit version;
@@ -54,6 +59,19 @@
               url = "https://github.com/5rahim/seanime/releases/download/v${version}/seanime-denshi-${version}_Linux_x86_64.AppImage";
               hash = "sha256-8erYkDgOE5Ma4X502JEyXpYnfrLagJA0i0ePuRE+N4s=";
             };
+            extraInstallCommands = ''
+              install -m 444 -D ${icon} $out/share/icons/hicolor/256x256/apps/seanime-denshi.png
+              mkdir -p $out/share/applications
+              cp -r ${pkgs.makeDesktopItem {
+                name = "seanime-denshi";
+                desktopName = "Seanime Denshi";
+                exec = "seanime-denshi %u";
+                icon = "seanime-denshi";
+                comment = "Anime and Manga media server desktop client";
+                categories = [ "AudioVideo" "Video" ];
+                keywords = [ "anime" "manga" "media" "streaming" ];
+              }}/share/applications/* $out/share/applications/
+            '';
             meta = {
               description = "Seanime Denshi desktop client";
               homepage = "https://seanime.app";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,116 @@
+{
+  description = "Seanime - self-hosted anime/manga media server";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+
+      perSystem = { pkgs, lib, ... }:
+        let
+          version = "3.5.2";
+
+          seanimeWeb = pkgs.buildNpmPackage {
+            pname = "seanime-web";
+            inherit version;
+            src = ./seanime-web;
+            npmDepsHash = "sha256-fWlK2h0RQF9GnEogXW3bwM01RCCDVij/9S2sn2BA3S4=";
+            buildPhase = "npm run build";
+            installPhase = "cp -r out $out";
+          };
+
+          seanime = pkgs.buildGoModule {
+            pname = "seanime";
+            inherit version;
+            src = ./.;
+            vendorHash = "sha256-TN9shH4B7XVDIa541+7MHTNQs1IKPRJW1dn8tmES5jg=";
+            subPackages = [ "." ];
+            env.CGO_ENABLED = 1;
+            nativeBuildInputs = with pkgs; [ gcc pkg-config ]
+              ++ lib.optionals pkgs.stdenv.isDarwin [
+                darwin.apple_sdk.frameworks.Security
+                darwin.apple_sdk.frameworks.CoreFoundation
+              ];
+            buildInputs = [ pkgs.sqlite ];
+            preBuild = "mkdir -p web && cp -r ${seanimeWeb}/* web/";
+            ldflags = [ "-s" "-w" ];
+            meta = {
+              description = "Self-hosted media server for anime and manga";
+              homepage = "https://seanime.app";
+              license = pkgs.lib.licenses.gpl3Only;
+              mainProgram = "seanime";
+              platforms = pkgs.lib.platforms.unix;
+            };
+          };
+
+          seanime-denshi = pkgs.appimageTools.wrapType2 {
+            pname = "seanime-denshi";
+            inherit version;
+            src = pkgs.fetchurl {
+              url = "https://github.com/5rahim/seanime/releases/download/v${version}/seanime-denshi-${version}_Linux_x86_64.AppImage";
+              hash = "sha256-8erYkDgOE5Ma4X502JEyXpYnfrLagJA0i0ePuRE+N4s=";
+            };
+            meta = {
+              description = "Seanime Denshi desktop client";
+              homepage = "https://seanime.app";
+              license = pkgs.lib.licenses.gpl3Only;
+              mainProgram = "seanime-denshi";
+              platforms = [ "x86_64-linux" ];
+            };
+          };
+        in
+        {
+          packages = {
+            inherit seanime seanimeWeb seanime-denshi;
+            default = seanime-denshi;
+          };
+
+          devShells.default = pkgs.mkShell {
+            buildInputs = with pkgs; [ go_1_23 gopls gotools nodejs_20 sqlite gcc pkg-config ];
+          };
+
+          formatter = pkgs.nixfmt-rfc-style;
+        };
+
+      flake.nixosModules.default = { config, lib, pkgs, ... }:
+        let cfg = config.services.seanime;
+            pkg = inputs.self.packages.${pkgs.system}.seanime;
+        in {
+          options.services.seanime = {
+            enable       = lib.mkEnableOption "Seanime media server";
+            dataDir      = lib.mkOption { type = lib.types.str; default = "/var/lib/seanime"; };
+            user         = lib.mkOption { type = lib.types.str; default = "seanime"; };
+            group        = lib.mkOption { type = lib.types.str; default = "seanime"; };
+            openFirewall = lib.mkOption { type = lib.types.bool; default = false; };
+          };
+
+          config = lib.mkIf cfg.enable {
+            users.users.${cfg.user}  = { isSystemUser = true; group = cfg.group; home = cfg.dataDir; createHome = true; };
+            users.groups.${cfg.group} = {};
+
+            systemd.services.seanime = {
+              description = "Seanime Media Server";
+              wantedBy = [ "multi-user.target" ];
+              after    = [ "network.target" ];
+              serviceConfig = {
+                ExecStart       = "${pkg}/bin/seanime --datadir=${cfg.dataDir}";
+                User            = cfg.user;
+                Group           = cfg.group;
+                Restart         = "on-failure";
+                RestartSec      = "5s";
+                NoNewPrivileges = true;
+                PrivateTmp      = true;
+                ProtectSystem   = "strict";
+                ReadWritePaths  = [ cfg.dataDir ];
+              };
+            };
+
+            networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ 43211 ];
+          };
+        };
+    };
+}


### PR DESCRIPTION
Adds a `flake.nix` for building Seanime on NixOS.

- `nix build .#seanime` — Go server with embedded web interface
- `nix build .#seanimeWeb` — frontend only
- `nix build .#seanime-denshi` — official AppImage wrapped as a Nix derivation
- `nix run .` — runs Seanime Denshi (default)
- `devShells.default` — dev shell with Go, Node.js, and all dependencies
- `nixosModules.default` — systemd service module

**Notes**
- `seanime-denshi` wraps the pre-built AppImage rather than building from source due to the custom Electron 39 build with codec patches
- Frontend and server are separate derivations for cache efficiency
- Tested on NixOS unstable x86_64-linux