### PR TITLE
fix: handle DOM event triggered events in plugin UI

### DIFF
--- a/internal/plugin/ui/ui.go
+++ b/internal/plugin/ui/ui.go
@@ -280,6 +280,12 @@ func (u *UI) dispatchClientEvent(clientEvent *ClientPluginEvent) {
 	case ClientActionRenderEpisodeGridItemMenuItemsEvent: // Client wants to update the episode grid item menu items
 		u.context.actionManager.renderEpisodeGridItemMenuItems()
 
+	case ClientDOMEventTriggeredEvent: // A DOM event was triggered on the client
+		var payload ClientDOMEventTriggeredEventPayload
+		if clientEvent.ParsePayloadAs(ClientDOMEventTriggeredEvent, &payload) {
+			u.context.domManager.HandleDOMEvent(payload.ElementId, payload.EventType, payload.Event)
+		}
+
 	case ClientRenderCommandPaletteEvent: // Client wants to render the command palette
 		u.context.commandPaletteManager.renderCommandPaletteScheduled()
 


### PR DESCRIPTION
`element.addEventListener()` in plugins registers a callback in `DOMManager.eventListeners` and sends a `ServerDOMManipulateEvent` to tell the client to attach a listener. When the user triggers the event on the client, it sends back a `ClientDOMEventTriggeredEvent` - but the server-side switch in [ui.go:283](/5rahim/seanime/tree/main/internal/plugin/ui/ui.go#L283) had no case for it, so it fell through to the default branch (generic event bus), and `DOMManager.HandleDOMEvent was never called`. All DOM event callbacks silently never fired.

**Fix**: Added the missing case `ClientDOMEventTriggeredEvent` that routes the payload to `domManager.HandleDOMEvent(elementId, eventType, eventData)`, which finds the matching registered listener and schedules the callback in the VM.