### PR TITLE
 feat(plugin): add videoCore.playStream and videoCore.playLocalFile for built-in player

### DIFF
--- a/internal/core/modules.go
+++ b/internal/core/modules.go
@@ -242,9 +242,10 @@ func (a *App) initModulesOnce() {
 	})
 
 	plugin.GlobalAppContext.SetModulesPartial(plugin.AppContextModules{
-		PlaybackManager: a.PlaybackManager,
-		MangaRepository: a.MangaRepository,
-		VideoCore:       a.VideoCore,
+		PlaybackManager:     a.PlaybackManager,
+		MangaRepository:     a.MangaRepository,
+		VideoCore:           a.VideoCore,
+		DirectStreamManager: a.DirectStreamManager,
 	})
 
 	// +---------------------+

--- a/internal/directstream/http_base_stream.go
+++ b/internal/directstream/http_base_stream.go
@@ -1,0 +1,349 @@
+package directstream
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"seanime/internal/library/anime"
+	"seanime/internal/mkvparser"
+	"seanime/internal/nativeplayer"
+	httputil "seanime/internal/util/http"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/samber/mo"
+)
+
+// httpBaseStream holds shared state and logic for HTTP URL-based streams (debrid, URL).
+type httpBaseStream struct {
+	BaseStream
+	streamUrl     string
+	contentLength int64
+	filepath      string
+	httpStream    *httputil.FileStream // Shared file-backed cache for multiple readers
+	cacheMu       sync.RWMutex        // Protects httpStream access
+}
+
+var videoProxyClient = &http.Client{
+	Transport: &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     90 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+		ForceAttemptHTTP2:   false, // Fixes issues on Linux
+	},
+}
+
+// Headers that should not be forwarded to the CDN
+var proxyHopHeaders = map[string]bool{
+	"Host":                true,
+	"Accept":              true,
+	"Accept-Encoding":     true,
+	"Range":               true,
+	"Connection":          true,
+	"Proxy-Connection":    true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Te":                  true,
+	"Trailer":             true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+}
+
+func (s *httpBaseStream) LoadContentType() string {
+	s.contentTypeOnce.Do(func() {
+		s.cacheMu.RLock()
+		if s.httpStream == nil {
+			s.cacheMu.RUnlock()
+			_ = s.initializeStream()
+		} else {
+			s.cacheMu.RUnlock()
+		}
+
+		info, ok := s.manager.FetchStreamInfo(s.streamUrl)
+		if !ok {
+			s.logger.Warn().Str("url", s.streamUrl).Msg("directstream(http): Failed to fetch stream info for content type")
+			return
+		}
+		s.logger.Debug().Str("url", s.streamUrl).Str("contentType", info.ContentType).Int64("contentLength", info.ContentLength).Msg("directstream(http): Fetched content type and length")
+		s.contentType = info.ContentType
+		if s.contentType == "application/force-download" {
+			s.contentType = "application/octet-stream"
+		}
+		s.contentLength = info.ContentLength
+	})
+
+	return s.contentType
+}
+
+// Close cleans up the HTTP cache and other resources
+func (s *httpBaseStream) Close() error {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+
+	s.logger.Debug().Msg("directstream(http): Closing HTTP cache")
+
+	if s.httpStream != nil {
+		if err := s.httpStream.Close(); err != nil {
+			s.logger.Error().Err(err).Msg("directstream(http): Failed to close HTTP cache")
+			return err
+		}
+		s.httpStream = nil
+	}
+
+	s.logger.Debug().Msg("directstream(http): HTTP cache closed successfully")
+
+	return nil
+}
+
+// Terminate overrides BaseStream.Terminate to also clean up the HTTP cache
+func (s *httpBaseStream) Terminate() {
+	// Clean up HTTP cache first
+	if err := s.Close(); err != nil {
+		s.logger.Error().Err(err).Msg("directstream(http): Failed to clean up HTTP cache during termination")
+	}
+
+	// Call the base implementation
+	s.BaseStream.Terminate()
+}
+
+// loadPlaybackInfo is called by concrete types, passing their own StreamType.
+func (s *httpBaseStream) loadPlaybackInfo(streamType nativeplayer.StreamType) (ret *nativeplayer.PlaybackInfo, err error) {
+	s.playbackInfoOnce.Do(func() {
+		if s.streamUrl == "" {
+			ret = &nativeplayer.PlaybackInfo{}
+			err = fmt.Errorf("stream url is not set")
+			s.playbackInfoErr = err
+			return
+		}
+
+		id := uuid.New().String()
+
+		var entryListData *anime.EntryListData
+		if animeCollection, ok := s.manager.animeCollection.Get(); ok {
+			if listEntry, ok := animeCollection.GetListEntryFromAnimeId(s.media.ID); ok {
+				entryListData = anime.NewEntryListData(listEntry)
+			}
+		}
+
+		contentType := s.LoadContentType()
+
+		playbackInfo := nativeplayer.PlaybackInfo{
+			ID:                id,
+			StreamType:        streamType,
+			StreamPath:        s.filepath,
+			MimeType:          contentType,
+			StreamUrl:         "{{SERVER_URL}}/api/v1/directstream/stream?id=" + id + s.manager.GetHMACTokenQueryParam("/api/v1/directstream/stream", "&"),
+			ContentLength:     s.contentLength, // loaded by LoadContentType
+			MkvMetadata:       nil,
+			MkvMetadataParser: mo.None[*mkvparser.MetadataParser](),
+			Episode:           s.episode,
+			Media:             s.media,
+			EntryListData:     entryListData,
+		}
+
+		// If the content type is an EBML content type, we can create a metadata parser
+		if isEbmlContent(s.LoadContentType()) || s.LoadContentType() == "application/octet-stream" || s.LoadContentType() == "application/force-download" {
+			//reader, readErr := s.getPriorityReader()
+			reader, readErr := httputil.NewHttpReadSeekerFromURL(s.streamUrl)
+			if readErr != nil {
+				err = fmt.Errorf("failed to create reader for stream url: %w", readErr)
+				s.logger.Error().Err(readErr).Msg("directstream(http): Failed to create reader for stream url")
+				s.playbackInfoErr = err
+				return
+			}
+			defer reader.Close() // Close this specific reader instance
+
+			_, _ = reader.Seek(0, io.SeekStart)
+			s.logger.Trace().Msgf("directstream(http): Loading metadata for stream url: %s", s.streamUrl)
+
+			parser := mkvparser.NewMetadataParser(reader, s.logger)
+			metadata := parser.GetMetadata(context.Background())
+			if metadata.Error != nil {
+				err = fmt.Errorf("failed to get metadata: %w", metadata.Error)
+				s.logger.Error().Err(metadata.Error).Msg("directstream(http): Failed to get metadata")
+				s.playbackInfoErr = err
+				return
+			}
+
+			playbackInfo.MkvMetadata = metadata
+			playbackInfo.MkvMetadataParser = mo.Some(parser)
+		}
+
+		s.playbackInfo = &playbackInfo
+	})
+
+	return s.playbackInfo, s.playbackInfoErr
+}
+
+// getStreamHandler is called by concrete types, passing themselves as the Stream interface
+// so that subtitle streaming uses the correct outer stream.
+func (s *httpBaseStream) getStreamHandler(outer Stream) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.streamUrl == "" {
+			s.logger.Error().Msg("directstream(http): No URL to stream")
+			http.Error(w, "No URL to stream", http.StatusNotFound)
+			return
+		}
+
+		if r.Method == http.MethodHead {
+			s.logger.Trace().Msg("directstream(http): Handling HEAD request")
+
+			fileSize := s.contentLength
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", fileSize))
+			w.Header().Set("Content-Type", s.LoadContentType())
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		rangeHeader := r.Header.Get("Range")
+
+		if err := s.initializeStream(); err != nil {
+			s.logger.Error().Err(err).Msg("directstream(http): Failed to initialize FileStream")
+			http.Error(w, "Failed to initialize FileStream", http.StatusInternalServerError)
+			return
+		}
+
+		reader, err := s.getReader()
+		if err != nil {
+			s.logger.Error().Err(err).Msg("directstream(http): Failed to create reader for stream url")
+			http.Error(w, "Failed to create reader for stream url", http.StatusInternalServerError)
+			return
+		}
+		defer reader.Close()
+
+		if isThumbnailRequest(r) {
+			ra, ok := handleRange(w, r, reader, s.filename, s.contentLength)
+			if !ok {
+				return
+			}
+			serveContentRange(w, r, r.Context(), reader, s.filename, s.contentLength, s.contentType, ra)
+			return
+		}
+
+		ra, ok := handleRange(w, r, reader, s.filename, s.contentLength)
+		if !ok {
+			return
+		}
+
+		if _, ok := s.playbackInfo.MkvMetadataParser.Get(); ok {
+			subReader, err := s.getReader()
+			if err != nil {
+				s.logger.Error().Err(err).Msg("directstream(http): Failed to create subtitle reader for stream url")
+				http.Error(w, "Failed to create subtitle reader for stream url", http.StatusInternalServerError)
+				return
+			}
+			if ra.Start < s.contentLength-1024*1024 {
+				// subReader is closed inside the subtitle goroutine
+				go s.StartSubtitleStreamP(outer, s.manager.playbackCtx, subReader, ra.Start, 0)
+			} else {
+				_ = subReader.Close()
+			}
+		}
+
+		// Use the client's request context so the CDN request is cancelled when the client disconnects
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, s.streamUrl, nil)
+		if err != nil {
+			http.Error(w, "Failed to create request", http.StatusInternalServerError)
+			return
+		}
+
+		req.Header.Set("Accept", "*/*")
+		req.Header.Set("Range", rangeHeader)
+
+		// Only forward safe headers to avoid conflicts with the CDN
+		for key, values := range r.Header {
+			if proxyHopHeaders[http.CanonicalHeaderKey(key)] {
+				continue
+			}
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+
+		resp, err := videoProxyClient.Do(req)
+		if err != nil {
+			s.logger.Error().Err(err).Str("range", rangeHeader).Msg("directstream(http): CDN proxy request failed")
+			http.Error(w, "Failed to proxy request", http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+
+		// Reject non-2xx CDN responses to avoid corrupting the file cache
+		if resp.StatusCode >= 300 {
+			s.logger.Error().Int("status", resp.StatusCode).Str("range", rangeHeader).Msg("directstream(http): CDN returned non-2xx status")
+			http.Error(w, fmt.Sprintf("CDN error: %d", resp.StatusCode), resp.StatusCode)
+			return
+		}
+
+		// Copy response headers
+		for key, values := range resp.Header {
+			for _, value := range values {
+				w.Header().Set(key, value)
+			}
+		}
+
+		w.Header().Set("Content-Type", s.LoadContentType()) // overwrite the type
+		w.WriteHeader(resp.StatusCode)
+
+		if err := s.httpStream.WriteAndFlush(resp.Body, w, ra.Start); err != nil {
+			s.logger.Warn().Err(err).Str("range", rangeHeader).Msg("directstream(http): WriteAndFlush error")
+		}
+	})
+}
+
+// initializeStream creates the HTTP cache for this stream if it doesn't exist
+func (s *httpBaseStream) initializeStream() error {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+
+	if s.httpStream != nil {
+		return nil // Already initialized
+	}
+
+	if s.streamUrl == "" {
+		return fmt.Errorf("stream URL is not set")
+	}
+
+	// Get content length first
+	if s.contentLength == 0 {
+		info, ok := s.manager.FetchStreamInfo(s.streamUrl)
+		if !ok {
+			return fmt.Errorf("failed to fetch stream info")
+		}
+		s.contentLength = info.ContentLength
+	}
+
+	s.logger.Debug().Msgf("directstream(http): Initializing FileStream for stream URL: %s", s.streamUrl)
+
+	// Create a file-backed stream with the known content length
+	cache, err := httputil.NewFileStream(s.manager.playbackCtx, s.logger, s.contentLength)
+	if err != nil {
+		return fmt.Errorf("failed to create FileStream: %w", err)
+	}
+
+	s.httpStream = cache
+
+	s.logger.Debug().Msgf("directstream(http): FileStream initialized")
+
+	return nil
+}
+
+func (s *httpBaseStream) getReader() (io.ReadSeekCloser, error) {
+	if err := s.initializeStream(); err != nil {
+		return nil, err
+	}
+
+	s.cacheMu.RLock()
+	defer s.cacheMu.RUnlock()
+
+	if s.httpStream == nil {
+		return nil, fmt.Errorf("FileStream not initialized")
+	}
+
+	return s.httpStream.NewReader()
+}

--- a/internal/directstream/stream.go
+++ b/internal/directstream/stream.go
@@ -709,12 +709,12 @@ func (m *Manager) getContentTypeAndLength(url string) (string, int64, error) {
 			}
 		}
 
-		// If we have content type, return early
-		if contentType != "" {
+		// If we have content type from a successful response, return early
+		if contentType != "" && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			return contentType, length, nil
 		}
 
-		m.Logger.Trace().Msg("directstream(debrid): Content type not found in HEAD response headers")
+		m.Logger.Trace().Int("status", resp.StatusCode).Msg("directstream(debrid): HEAD response not usable, falling back to GET")
 	} else {
 		m.Logger.Trace().Err(err).Msg("directstream(debrid): HEAD request failed")
 	}

--- a/internal/directstream/urlstream.go
+++ b/internal/directstream/urlstream.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"seanime/internal/api/anilist"
-	hibiketorrent "seanime/internal/extension/hibike/torrent"
 	"seanime/internal/library/anime"
 	"seanime/internal/mkvparser"
 	"seanime/internal/nativeplayer"
@@ -13,48 +12,43 @@ import (
 )
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Debrid
+// URL Stream
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-var _ Stream = (*DebridStream)(nil)
+var _ Stream = (*URLStream)(nil)
 
-// DebridStream is a stream sourced from a debrid provider.
-type DebridStream struct {
+// URLStream is an HTTP-proxied stream sourced from an arbitrary URL (e.g. from a plugin).
+type URLStream struct {
 	httpBaseStream
-	torrent       *hibiketorrent.AnimeTorrent
-	streamReadyCh chan struct{} // Closed by the initiator when the stream URL is resolved
 }
 
-func (s *DebridStream) Type() nativeplayer.StreamType {
-	return nativeplayer.StreamTypeDebrid
+func (s *URLStream) Type() nativeplayer.StreamType {
+	return nativeplayer.StreamTypeURL
 }
 
-func (s *DebridStream) LoadPlaybackInfo() (*nativeplayer.PlaybackInfo, error) {
+func (s *URLStream) LoadPlaybackInfo() (*nativeplayer.PlaybackInfo, error) {
 	return s.httpBaseStream.loadPlaybackInfo(s.Type())
 }
 
-func (s *DebridStream) GetStreamHandler() http.Handler {
+func (s *URLStream) GetStreamHandler() http.Handler {
 	return s.httpBaseStream.getStreamHandler(s)
 }
 
-func (s *DebridStream) GetAttachmentByName(filename string) (*mkvparser.AttachmentInfo, bool) {
+func (s *URLStream) GetAttachmentByName(filename string) (*mkvparser.AttachmentInfo, bool) {
 	return getAttachmentByName(s.manager.playbackCtx, s, filename)
 }
 
-type PlayDebridStreamOptions struct {
+type PlayURLStreamOptions struct {
 	StreamUrl    string
-	MediaId      int
-	AnidbEpisode string // Anizip episode
+	AnidbEpisode string
 	Media        *anilist.BaseAnime
-	Torrent      *hibiketorrent.AnimeTorrent // Selected torrent
-	FileId       string                      // File ID or index
-	UserAgent    string
 	ClientId     string
-	AutoSelect   bool
 }
 
-// PlayDebridStream is used by a module to load a new debrid stream.
-func (m *Manager) PlayDebridStream(ctx context.Context, filepath string, opts PlayDebridStreamOptions) error {
+// PlayURLStream starts built-in player playback for an arbitrary HTTP URL with progress tracking.
+func (m *Manager) PlayURLStream(ctx context.Context, opts PlayURLStreamOptions) error {
+	m.ResetOpenState(opts.ClientId)
+
 	episodeCollection, err := anime.NewEpisodeCollection(anime.NewEpisodeCollectionOptions{
 		AnimeMetadata:       nil,
 		Media:               opts.Media,
@@ -62,37 +56,32 @@ func (m *Manager) PlayDebridStream(ctx context.Context, filepath string, opts Pl
 		Logger:              m.Logger,
 	})
 	if err != nil {
-		return fmt.Errorf("cannot play local file, could not create episode collection: %w", err)
+		return fmt.Errorf("cannot play URL stream, could not create episode collection: %w", err)
 	}
 
 	episode, ok := episodeCollection.FindEpisodeByAniDB(opts.AnidbEpisode)
 	if !ok {
-		return fmt.Errorf("cannot play debrid stream, could not find episode: %s", opts.AnidbEpisode)
+		return fmt.Errorf("cannot play URL stream, could not find episode: %s", opts.AnidbEpisode)
 	}
 
-	stream := &DebridStream{
-		torrent: opts.Torrent,
+	stream := &URLStream{
 		httpBaseStream: httpBaseStream{
 			streamUrl: opts.StreamUrl,
-			filepath:  filepath,
+			filepath:  "",
 			BaseStream: BaseStream{
 				manager:               m,
 				logger:                m.Logger,
 				clientId:              opts.ClientId,
 				media:                 opts.Media,
-				filename:              "",
 				episode:               episode,
 				episodeCollection:     episodeCollection,
 				subtitleEventCache:    result.NewMap[string, *mkvparser.SubtitleEvent](),
 				activeSubtitleStreams: result.NewMap[string, *SubtitleStream](),
 			},
 		},
-		streamReadyCh: make(chan struct{}),
 	}
 
-	go func() {
-		m.loadStream(stream)
-	}()
+	go m.loadStream(stream)
 
 	return nil
 }

--- a/internal/extension_repo/goja_plugin_types/plugin.d.ts
+++ b/internal/extension_repo/goja_plugin_types/plugin.d.ts
@@ -2918,6 +2918,25 @@ declare namespace $ui {
          * @returns The playback type or empty string
          */
         getCurrentPlaybackType(): PlaybackType | ""
+
+        /**
+         * Start playback of a URL in the built-in player with progress tracking.
+         * The promise resolves once the stream has been initiated (not when playback completes).
+         * @param streamUrl - The URL to stream
+         * @param anidbEpisode - AniDB episode identifier (e.g. "1", "S1") - used for progress tracking
+         * @param media - The anime object - used for progress tracking
+         * @returns A promise that resolves when the stream has started
+         */
+        playStream(streamUrl: string, anidbEpisode: string, media: $app.AL_BaseAnime): Promise<void>
+
+        /**
+         * Start playback of a local file in the built-in player with progress tracking.
+         * The promise resolves once the stream has been initiated (not when playback completes).
+         * The file must be in the scanned library.
+         * @param path - Absolute path to the local file
+         * @returns A promise that resolves when the stream has started
+         */
+        playLocalFile(path: string): Promise<void>
     }
 }
 

--- a/internal/nativeplayer/nativeplayer.go
+++ b/internal/nativeplayer/nativeplayer.go
@@ -18,6 +18,7 @@ const (
 	StreamTypeTorrent StreamType = "torrent"
 	StreamTypeFile    StreamType = "localfile"
 	StreamTypeDebrid  StreamType = "debrid"
+	StreamTypeURL     StreamType = "url"
 	StreamTypeNakama  StreamType = "nakama"
 )
 

--- a/internal/plugin/app_context.go
+++ b/internal/plugin/app_context.go
@@ -6,6 +6,7 @@ import (
 	"seanime/internal/database/db"
 	"seanime/internal/database/models"
 	discordrpc_presence "seanime/internal/discordrpc/presence"
+	"seanime/internal/directstream"
 	"seanime/internal/events"
 	"seanime/internal/extension"
 	"seanime/internal/library/autodownloader"
@@ -50,6 +51,7 @@ type AppContextModules struct {
 	TorrentstreamRepository         *torrentstream.Repository
 	FillerManager                   *fillermanager.FillerManager
 	VideoCore                       *videocore.VideoCore
+	DirectStreamManager             *directstream.Manager
 	OnRefreshAnilistAnimeCollection func()
 	OnRefreshAnilistMangaCollection func()
 }
@@ -65,6 +67,7 @@ type AppContext interface {
 	Database() mo.Option[*db.Database]
 	PlaybackManager() mo.Option[*playbackmanager.PlaybackManager]
 	VideoCore() mo.Option[*videocore.VideoCore]
+	DirectStreamManager() mo.Option[*directstream.Manager]
 	MediaPlayerRepository() mo.Option[*mediaplayer.Repository]
 	AnilistPlatformRef() mo.Option[*util.Ref[platform.Platform]]
 	WSEventManager() mo.Option[events.WSEventManagerInterface]
@@ -165,6 +168,7 @@ type AppContextImpl struct {
 	onRefreshAnilistAnimeCollection mo.Option[func()]
 	onRefreshAnilistMangaCollection mo.Option[func()]
 	videoCore                       mo.Option[*videocore.VideoCore]
+	directStreamManager             mo.Option[*directstream.Manager]
 	isOfflineRef                    *util.Ref[bool]
 }
 
@@ -192,6 +196,7 @@ func NewAppContext() AppContext {
 		onRefreshAnilistAnimeCollection: mo.None[func()](),
 		onRefreshAnilistMangaCollection: mo.None[func()](),
 		videoCore:                       mo.None[*videocore.VideoCore](),
+		directStreamManager:             mo.None[*directstream.Manager](),
 		isOfflineRef:                    util.NewRef(false),
 	}
 
@@ -216,6 +221,10 @@ func (a *AppContextImpl) PlaybackManager() mo.Option[*playbackmanager.PlaybackMa
 
 func (a *AppContextImpl) VideoCore() mo.Option[*videocore.VideoCore] {
 	return a.videoCore
+}
+
+func (a *AppContextImpl) DirectStreamManager() mo.Option[*directstream.Manager] {
+	return a.directStreamManager
 }
 
 func (a *AppContextImpl) MediaPlayerRepository() mo.Option[*mediaplayer.Repository] {
@@ -317,6 +326,10 @@ func (a *AppContextImpl) SetModulesPartial(modules AppContextModules) {
 
 	if modules.VideoCore != nil {
 		a.videoCore = mo.Some(modules.VideoCore)
+	}
+
+	if modules.DirectStreamManager != nil {
+		a.directStreamManager = mo.Some(modules.DirectStreamManager)
 	}
 }
 

--- a/internal/plugin/videocore.go
+++ b/internal/plugin/videocore.go
@@ -1,7 +1,11 @@
 package plugin
 
 import (
+	"context"
 	"errors"
+	"seanime/internal/api/anilist"
+	"seanime/internal/database/db_bridge"
+	"seanime/internal/directstream"
 	"seanime/internal/extension"
 	"seanime/internal/mkvparser"
 	gojautil "seanime/internal/util/goja"
@@ -91,10 +95,98 @@ func (a *AppContextImpl) BindVideoCoreToContextObj(vm *goja.Runtime, obj *goja.O
 	_ = vcObj.Set("getCurrentPlayerType", p.getCurrentPlayerType)
 	_ = vcObj.Set("getCurrentPlaybackType", p.getCurrentPlaybackType)
 
+	// Initiate playback
+	_ = vcObj.Set("playStream", p.playStream)
+	_ = vcObj.Set("playLocalFile", p.playLocalFile)
+
 	//_ = vcObj.Set("startOnlinestreamWatchParty", p.startOnlinestreamWatchParty)
 
 	_ = obj.Set("videoCore", vcObj)
 
+}
+
+// playStream resolves once the stream is initiated, not when playback completes.
+func (p *VideoCore) playStream(streamUrl string, anidbEpisode string, media *anilist.BaseAnime) goja.Value {
+	promise, resolve, reject := p.vm.NewPromise()
+
+	dsManager, ok := p.ctx.DirectStreamManager().Get()
+	if !ok {
+		reject(p.vm.NewGoError(errors.New("directstream manager not available")))
+		return p.vm.ToValue(promise)
+	}
+
+	if streamUrl == "" || anidbEpisode == "" || media == nil {
+		reject(p.vm.NewGoError(errors.New("playStream: streamUrl, anidbEpisode, and media are required")))
+		return p.vm.ToValue(promise)
+	}
+
+	opts := directstream.PlayURLStreamOptions{
+		StreamUrl:    streamUrl,
+		AnidbEpisode: anidbEpisode,
+		Media:        media,
+	}
+
+	go func() {
+		playErr := dsManager.PlayURLStream(context.Background(), opts)
+		p.scheduler.ScheduleAsync(func() error {
+			if playErr != nil {
+				reject(p.vm.NewGoError(playErr))
+			} else {
+				resolve(nil)
+			}
+			return nil
+		})
+	}()
+
+	return p.vm.ToValue(promise)
+}
+
+// playLocalFile resolves once the stream is initiated, not when playback completes.
+func (p *VideoCore) playLocalFile(path string) goja.Value {
+	promise, resolve, reject := p.vm.NewPromise()
+
+	dsManager, ok := p.ctx.DirectStreamManager().Get()
+	if !ok {
+		reject(p.vm.NewGoError(errors.New("directstream manager not available")))
+		return p.vm.ToValue(promise)
+	}
+
+	db, ok := p.ctx.Database().Get()
+	if !ok {
+		reject(p.vm.NewGoError(errors.New("database not available")))
+		return p.vm.ToValue(promise)
+	}
+
+	if path == "" {
+		reject(p.vm.NewGoError(errors.New("playLocalFile: path is required")))
+		return p.vm.ToValue(promise)
+	}
+
+	go func() {
+		lfs, _, err := db_bridge.GetLocalFiles(db)
+		if err != nil {
+			p.scheduler.ScheduleAsync(func() error {
+				reject(p.vm.NewGoError(err))
+				return nil
+			})
+			return
+		}
+
+		playErr := dsManager.PlayLocalFile(context.Background(), directstream.PlayLocalFileOptions{
+			Path:       path,
+			LocalFiles: lfs,
+		})
+		p.scheduler.ScheduleAsync(func() error {
+			if playErr != nil {
+				reject(p.vm.NewGoError(playErr))
+			} else {
+				resolve(nil)
+			}
+			return nil
+		})
+	}()
+
+	return p.vm.ToValue(promise)
 }
 
 type VideoCoreEvent struct {


### PR DESCRIPTION
This PR adds 2 methods under ctx.videoCore for plugins that enables them to start streams in the built-in player using a URL or scanned file path. 



