### PR TITLE
fix(plugin/webview): prevent stale state overwriting fresh updates

### DIFF
--- a/internal/plugin/ui/webview.go
+++ b/internal/plugin/ui/webview.go
@@ -803,12 +803,12 @@ func (c *WebviewChannel) jsSync(call goja.FunctionCall) goja.Value {
 			c.sendStateToWebview(key, state.Value.Export())
 			// send the value again just in case
 			go func() {
+				time.Sleep(1000 * time.Millisecond)
 				state, ok := c.webview.webviewManager.ctx.states.Get(stateID)
 				if !ok {
 					c.webview.webviewManager.ctx.handleTypeError("sync: state not found")
 					return
 				}
-				time.Sleep(1000 * time.Millisecond)
 				c.sendStateToWebview(key, state.Value.Export())
 			}()
 		}


### PR DESCRIPTION
`WebviewChannel.jsSync` includes a re-send that fires 1 second after the iframe loads. Because the re-send captures the `*State` **pointer** before sleeping - and `state.set(...)` replaces the map entry with a brand new `*State` rather than mutating the existing one - the re-send transmits the value that was current 1 second ago, not the current value.

In practice this means any state update delivered in the first ~1s after the iframe loads is silently overwritten by a stale snapshot. 

