### PR TITLE
fix(debrid): resume interrupted TorBox downloads

### DIFF
--- a/internal/debrid/client/download.go
+++ b/internal/debrid/client/download.go
@@ -18,9 +18,19 @@ import (
 	"seanime/internal/notifier"
 	"seanime/internal/util"
 	"seanime/internal/util/result"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
+)
+
+var (
+	debridDownloadMaxAttempts      = 8
+	debridDownloadInitialBackoff   = time.Second
+	debridDownloadMaxBackoff       = 30 * time.Second
+	errInvalidDownloadStatus       = errors.New("invalid download response status")
+	errInvalidDownloadContentRange = errors.New("invalid download content range")
 )
 
 func (r *Repository) launchDownloadLoop(ctx context.Context) {
@@ -147,6 +157,8 @@ func (r *Repository) downloadTorrentItem(tId string, torrentName string, destina
 		wg := sync.WaitGroup{}
 		downloadUrls := strings.Split(downloadUrl, ",")
 		downloadMap := result.NewMap[string, downloadStatus]()
+		var failed atomic.Bool
+		var cancelOnce sync.Once
 
 		for _, url := range downloadUrls {
 			wg.Add(1)
@@ -156,11 +168,17 @@ func (r *Repository) downloadTorrentItem(tId string, torrentName string, destina
 				// Download the file
 				ok := r.downloadFile(ctx, tId, url, destination, downloadMap)
 				if !ok {
+					failed.Store(true)
+					cancelOnce.Do(cancel)
 					return
 				}
 			}(ctx, url)
 		}
 		wg.Wait()
+
+		if failed.Load() {
+			return
+		}
 
 		r.sendDownloadCompletedEvent(tId, torrentName, destination)
 		notifier.GlobalNotifier.Notify(notifier.Debrid, fmt.Sprintf("Downloaded %q", torrentName))
@@ -173,13 +191,6 @@ func (r *Repository) downloadFile(ctx context.Context, tId string, downloadUrl s
 	defer util.HandlePanicInModuleThen("debrid/client/downloadFile", func() {
 		ok = false
 	})
-
-	// Create a cancellable HTTP request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadUrl, nil)
-	if err != nil {
-		r.logger.Err(err).Str("downloadUrl", downloadUrl).Msg("debrid: Failed to create request")
-		return false
-	}
 
 	_ = os.MkdirAll(destination, os.ModePerm)
 
@@ -200,142 +211,23 @@ func (r *Repository) downloadFile(ctx context.Context, tId string, downloadUrl s
 		time.Sleep(time.Millisecond * 500)
 	}
 
-	// Execute the request
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	r.logger.Debug().Str("downloadUrl", downloadUrl).Msg("debrid: Starting download")
+	downloadedFile, err := r.downloadHTTPFile(ctx, tId, downloadUrl, tmpDirPath, downloadMap)
 	if err != nil {
-		r.logger.Err(err).Str("downloadUrl", downloadUrl).Msg("debrid: Failed to execute request")
-		r.wsEventManager.SendEvent(events.ErrorToast, fmt.Sprintf("debrid: Failed to execute download request: %v", err))
-		return false
-	}
-	defer resp.Body.Close()
-
-	// e.g. "Torrent Name.zip", "downloaded_torrent"
-	// defaults to downloaded_torrent.{ext} if we can't guess the name
-	filename := "downloaded_torrent"
-	ext := ""
-
-	// Try to get the file name from the Content-Disposition header
-	// Probably doesn't work for any provider
-	hFilename, err := getFilenameFromHeaders(downloadUrl)
-	if err == nil {
-		r.logger.Warn().Str("newFilename", hFilename).Str("defaultFilename", filename).Msg("debrid: Filename found in headers, overriding default")
-		filename = hFilename
-	}
-
-	// The case for TorBox(?)
-	// RD will return application/force-download so ext will still be empty
-	if ct := resp.Header.Get("Content-Type"); ct != "" {
-		mediaType, _, err := mime.ParseMediaType(ct)
-		if err == nil {
-			switch mediaType {
-			case "application/zip":
-				ext = ".zip"
-			case "application/x-rar-compressed":
-				ext = ".rar"
-			default:
-			}
-			r.logger.Debug().Str("mediaType", mediaType).Str("ext", ext).Msg("debrid: Detected media type and extension")
+		if errors.Is(err, context.Canceled) {
+			r.logger.Debug().Msg("debrid: Download cancelled")
+		} else {
+			r.logger.Err(err).Str("downloadUrl", downloadUrl).Msg("debrid: Download failed")
+			r.wsEventManager.SendEvent(events.ErrorToast, fmt.Sprintf("debrid: Download failed: %v", err))
 		}
-	}
-
-	// add the file extension to downloaded_torrent if we couldn't guess the name from headers
-	if filename == "downloaded_torrent" && ext != "" {
-		filename = fmt.Sprintf("%s%s", filename, ext)
-	}
-
-	// Check if the download URL has the extension
-	// This works for RD, by that point we should have "Torrent Name.zip" or "Episode.mkv"
-	urlExt := filepath.Ext(downloadUrl)
-	if filename == "downloaded_torrent" && urlExt != "" {
-		filename = filepath.Base(downloadUrl)
-		filename, _ = url.PathUnescape(filename)
-		ext = urlExt
-		r.logger.Debug().Str("urlExt", urlExt).Str("filename", filename).Str("downloadUrl", downloadUrl).Msg("debrid: Extension found in URL, using it as file extension and file name")
-	}
-
-	r.logger.Debug().Str("filename", filename).Str("ext", ext).Msg("debrid: Starting download")
-
-	// Create a file in the temporary folder to store the download
-	//	/path/to/destination/.tmp-123456789/
-	//		Torrent Name.zip | downloaded_torrent.zip | Episode.mkv
-	tmpDownloadedFilePath := filepath.Join(tmpDirPath, filename)
-	file, err := os.Create(tmpDownloadedFilePath)
-	if err != nil {
-		r.logger.Err(err).Str("tmpDownloadedFilePath", tmpDownloadedFilePath).Msg("debrid: Failed to create temp file")
-		r.wsEventManager.SendEvent(events.ErrorToast, fmt.Sprintf("debrid: Failed to create temp file: %v", err))
+		r.sendDownloadCancelledEvent(tId, downloadUrl, downloadMap)
 		return false
 	}
 
-	totalSize := resp.ContentLength
-	speed := 0
+	filename := downloadedFile.Filename
+	ext := downloadedFile.Ext
 
-	lastSent := time.Now()
-
-	// Copy response body to the temporary file
-	buffer := make([]byte, 32*1024)
-	var totalBytes int64
-	var lastBytes int64
-	for {
-		n, err := resp.Body.Read(buffer)
-		if n > 0 {
-			_, writeErr := file.Write(buffer[:n])
-			if writeErr != nil {
-				_ = file.Close()
-				r.logger.Err(writeErr).Str("tmpDownloadedFilePath", tmpDownloadedFilePath).Msg("debrid: Failed to write to temp file")
-				r.wsEventManager.SendEvent(events.ErrorToast, fmt.Sprintf("debrid: Download failed / Failed to write to temp file: %v", writeErr))
-				r.sendDownloadCancelledEvent(tId, downloadUrl, downloadMap)
-				return false
-			}
-			totalBytes += int64(n)
-			if totalSize > 0 {
-				speed = int((totalBytes - lastBytes) / 1024) // KB/s
-				lastBytes = totalBytes
-			}
-
-			downloadMap.Set(downloadUrl, downloadStatus{
-				TotalBytes: totalBytes,
-				TotalSize:  totalSize,
-			})
-
-			if time.Since(lastSent) > time.Second*2 {
-				_totalBytes := uint64(0)
-				_totalSize := uint64(0)
-				downloadMap.Range(func(key string, value downloadStatus) bool {
-					_totalBytes += uint64(value.TotalBytes)
-					_totalSize += uint64(value.TotalSize)
-					return true
-				})
-				// Notify progress
-				r.wsEventManager.SendEvent(events.DebridDownloadProgress, map[string]interface{}{
-					"status":     "downloading",
-					"itemID":     tId,
-					"totalBytes": util.Bytes(_totalBytes),
-					"totalSize":  util.Bytes(_totalSize),
-					"speed":      speed,
-				})
-				lastSent = time.Now()
-			}
-		}
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			if errors.Is(err, context.Canceled) {
-				_ = file.Close()
-				r.logger.Debug().Msg("debrid: Download cancelled")
-				r.sendDownloadCancelledEvent(tId, downloadUrl, downloadMap)
-				return false
-			}
-			_ = file.Close()
-			r.logger.Err(err).Str("downloadUrl", downloadUrl).Msg("debrid: Failed to read from response body")
-			r.wsEventManager.SendEvent(events.ErrorToast, fmt.Sprintf("debrid: Download failed / Failed to read from response body: %v", err))
-			r.sendDownloadCancelledEvent(tId, downloadUrl, downloadMap)
-			return false
-		}
-	}
-
-	_ = file.Close()
+	r.logger.Debug().Str("filename", filename).Str("ext", ext).Msg("debrid: Downloaded file ready")
 
 	downloadMap.Delete(downloadUrl)
 
@@ -358,6 +250,7 @@ func (r *Repository) downloadFile(ctx context.Context, tId string, downloadUrl s
 
 	// Extract the downloaded file
 	var extractedDir string
+	tmpDownloadedFilePath := downloadedFile.Path
 	switch ext {
 	case ".zip":
 		//	/path/to/destination/.tmp-123456789/downlooaded_torrent.zip -> /path/to/destination/.tmp-123456789/extracted-1234/...
@@ -411,6 +304,353 @@ func (r *Repository) downloadFile(ctx context.Context, tId string, downloadUrl s
 	return true
 }
 
+type resumableDownloadResult struct {
+	Path     string
+	Filename string
+	Ext      string
+}
+
+type downloadContentRange struct {
+	Start int64
+	End   int64
+	Size  int64
+}
+
+func (r *Repository) downloadHTTPFile(ctx context.Context, tId string, downloadUrl string, tmpDirPath string, downloadMap *result.Map[string, downloadStatus]) (*resumableDownloadResult, error) {
+	client := &http.Client{}
+	backoff := debridDownloadInitialBackoff
+	written := int64(0)
+	expectedSize := int64(-1)
+	lastBytes := int64(0)
+	lastSent := time.Now()
+
+	result := &resumableDownloadResult{
+		Filename: "downloaded_torrent",
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= debridDownloadMaxAttempts; attempt++ {
+		rangeStart := written
+		resp, err := r.openDownloadResponse(ctx, client, downloadUrl, rangeStart)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil, err
+			}
+			lastErr = err
+			r.logger.Warn().Err(err).Int("attempt", attempt).Str("downloadUrl", downloadUrl).Msg("debrid: Download request failed, retrying")
+			if err := waitBeforeDebridDownloadRetry(ctx, attempt, backoff); err != nil {
+				return nil, err
+			}
+			backoff = nextDebridDownloadBackoff(backoff)
+			continue
+		}
+
+		appendFile, responseExpectedSize, err := validateDebridDownloadResponse(resp, rangeStart)
+		if err != nil {
+			_ = resp.Body.Close()
+			if errors.Is(err, errInvalidDownloadStatus) || errors.Is(err, errInvalidDownloadContentRange) {
+				return nil, err
+			}
+			lastErr = err
+			if err := waitBeforeDebridDownloadRetry(ctx, attempt, backoff); err != nil {
+				return nil, err
+			}
+			backoff = nextDebridDownloadBackoff(backoff)
+			continue
+		}
+
+		if responseExpectedSize >= 0 {
+			expectedSize = responseExpectedSize
+		}
+
+		if result.Path == "" {
+			result.Filename, result.Ext = getDownloadFilename(downloadUrl, resp.Header)
+			result.Path = filepath.Join(tmpDirPath, result.Filename)
+		}
+
+		if !appendFile {
+			written = 0
+			lastBytes = 0
+			rangeStart = 0
+		}
+
+		fileFlag := os.O_WRONLY | os.O_CREATE
+		if appendFile {
+			fileFlag |= os.O_APPEND
+		} else {
+			fileFlag |= os.O_TRUNC
+		}
+
+		file, err := os.OpenFile(result.Path, fileFlag, 0644)
+		if err != nil {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("failed to create temp file: %w", err)
+		}
+
+		err = r.copyDownloadResponseBody(ctx, resp.Body, file, tId, downloadUrl, downloadMap, &written, &lastBytes, expectedSize, &lastSent)
+		bodyCloseErr := resp.Body.Close()
+		fileCloseErr := file.Close()
+		if bodyCloseErr != nil && err == nil {
+			err = bodyCloseErr
+		}
+		if fileCloseErr != nil {
+			return nil, fmt.Errorf("failed to close temp file: %w", fileCloseErr)
+		}
+
+		if err == nil && expectedSize >= 0 && written != expectedSize {
+			err = fmt.Errorf("%w: downloaded %d of %d bytes", io.ErrUnexpectedEOF, written, expectedSize)
+		}
+
+		if err == nil {
+			return result, nil
+		}
+
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
+
+		lastErr = err
+		r.logger.Warn().Err(err).Int("attempt", attempt).Int64("written", written).Int64("expectedSize", expectedSize).Str("downloadUrl", downloadUrl).Msg("debrid: Download attempt failed, retrying")
+		if err := waitBeforeDebridDownloadRetry(ctx, attempt, backoff); err != nil {
+			return nil, err
+		}
+		backoff = nextDebridDownloadBackoff(backoff)
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("download failed")
+	}
+	return nil, fmt.Errorf("download failed after %d attempts: %w", debridDownloadMaxAttempts, lastErr)
+}
+
+func (r *Repository) openDownloadResponse(ctx context.Context, client *http.Client, downloadUrl string, rangeStart int64) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadUrl, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if rangeStart > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", rangeStart))
+	}
+	return client.Do(req)
+}
+
+func validateDebridDownloadResponse(resp *http.Response, rangeStart int64) (appendFile bool, expectedSize int64, err error) {
+	expectedSize = -1
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		if resp.ContentLength >= 0 {
+			expectedSize = resp.ContentLength
+		}
+		return false, expectedSize, nil
+	case http.StatusPartialContent:
+		contentRange, err := parseDownloadContentRange(resp.Header.Get("Content-Range"))
+		if err != nil {
+			return false, -1, fmt.Errorf("%w: %v", errInvalidDownloadContentRange, err)
+		}
+		if contentRange.Start != rangeStart {
+			return false, -1, fmt.Errorf("%w: expected start %d, got %d", errInvalidDownloadContentRange, rangeStart, contentRange.Start)
+		}
+		if contentRange.Size >= 0 {
+			expectedSize = contentRange.Size
+		}
+		return rangeStart > 0, expectedSize, nil
+	default:
+		return false, -1, fmt.Errorf("%w: %s", errInvalidDownloadStatus, resp.Status)
+	}
+}
+
+func parseDownloadContentRange(value string) (downloadContentRange, error) {
+	matches := regexp.MustCompile(`^bytes (\d+)-(\d+)/(\d+|\*)$`).FindStringSubmatch(value)
+	if len(matches) != 4 {
+		return downloadContentRange{}, fmt.Errorf("malformed Content-Range %q", value)
+	}
+
+	start, err := strconv.ParseInt(matches[1], 10, 64)
+	if err != nil {
+		return downloadContentRange{}, err
+	}
+	end, err := strconv.ParseInt(matches[2], 10, 64)
+	if err != nil {
+		return downloadContentRange{}, err
+	}
+	if end < start {
+		return downloadContentRange{}, fmt.Errorf("end before start")
+	}
+
+	size := int64(-1)
+	if matches[3] != "*" {
+		size, err = strconv.ParseInt(matches[3], 10, 64)
+		if err != nil {
+			return downloadContentRange{}, err
+		}
+		if size <= end {
+			return downloadContentRange{}, fmt.Errorf("size before end")
+		}
+	}
+
+	return downloadContentRange{Start: start, End: end, Size: size}, nil
+}
+
+func (r *Repository) copyDownloadResponseBody(
+	ctx context.Context,
+	body io.Reader,
+	file *os.File,
+	tId string,
+	downloadUrl string,
+	downloadMap *result.Map[string, downloadStatus],
+	written *int64,
+	lastBytes *int64,
+	expectedSize int64,
+	lastSent *time.Time,
+) error {
+	buffer := make([]byte, 32*1024)
+	for {
+		n, err := body.Read(buffer)
+		if n > 0 {
+			if _, writeErr := file.Write(buffer[:n]); writeErr != nil {
+				return fmt.Errorf("failed to write to temp file: %w", writeErr)
+			}
+			*written += int64(n)
+			r.updateDownloadProgress(tId, downloadUrl, downloadMap, *written, expectedSize, lastBytes, lastSent)
+		}
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return context.Canceled
+			}
+			return err
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return context.Canceled
+		}
+	}
+}
+
+func (r *Repository) updateDownloadProgress(tId string, downloadUrl string, downloadMap *result.Map[string, downloadStatus], totalBytes int64, totalSize int64, lastBytes *int64, lastSent *time.Time) {
+	speed := 0
+	if totalSize > 0 {
+		speed = int((totalBytes - *lastBytes) / 1024) // KB/s
+		*lastBytes = totalBytes
+	}
+
+	progressSize := totalSize
+	if progressSize < 0 {
+		progressSize = 0
+	}
+
+	downloadMap.Set(downloadUrl, downloadStatus{
+		TotalBytes: totalBytes,
+		TotalSize:  progressSize,
+	})
+
+	if time.Since(*lastSent) <= time.Second*2 {
+		return
+	}
+
+	_totalBytes := uint64(0)
+	_totalSize := uint64(0)
+	downloadMap.Range(func(key string, value downloadStatus) bool {
+		_totalBytes += uint64(value.TotalBytes)
+		_totalSize += uint64(value.TotalSize)
+		return true
+	})
+	// Notify progress
+	r.wsEventManager.SendEvent(events.DebridDownloadProgress, map[string]interface{}{
+		"status":     "downloading",
+		"itemID":     tId,
+		"totalBytes": util.Bytes(_totalBytes),
+		"totalSize":  util.Bytes(_totalSize),
+		"speed":      speed,
+	})
+	*lastSent = time.Now()
+}
+
+func waitBeforeDebridDownloadRetry(ctx context.Context, attempt int, backoff time.Duration) error {
+	if attempt >= debridDownloadMaxAttempts {
+		return nil
+	}
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return context.Canceled
+	case <-timer.C:
+		return nil
+	}
+}
+
+func nextDebridDownloadBackoff(backoff time.Duration) time.Duration {
+	backoff *= 2
+	if backoff > debridDownloadMaxBackoff {
+		return debridDownloadMaxBackoff
+	}
+	return backoff
+}
+
+func getDownloadFilename(downloadUrl string, headers http.Header) (filename string, ext string) {
+	filename = "downloaded_torrent"
+
+	if hFilename, ok := getFilenameFromContentDisposition(headers); ok {
+		filename = hFilename
+		ext = filepath.Ext(filename)
+	}
+
+	// The case for TorBox(?)
+	// RD will return application/force-download so ext will still be empty.
+	if ct := headers.Get("Content-Type"); ct != "" && ext == "" {
+		mediaType, _, err := mime.ParseMediaType(ct)
+		if err == nil {
+			switch mediaType {
+			case "application/zip":
+				ext = ".zip"
+			case "application/x-rar-compressed":
+				ext = ".rar"
+			default:
+			}
+		}
+	}
+
+	// Check if the download URL has the extension.
+	// This works for RD, by that point we should have "Torrent Name.zip" or "Episode.mkv".
+	if filename == "downloaded_torrent" && ext == "" {
+		urlExt := filepath.Ext(downloadUrl)
+		if urlExt != "" {
+			filename = filepath.Base(downloadUrl)
+			filename, _ = url.PathUnescape(filename)
+			ext = urlExt
+		}
+	}
+
+	// Add the file extension to downloaded_torrent if we couldn't guess the name from headers or URL.
+	if filename == "downloaded_torrent" && ext != "" {
+		filename = fmt.Sprintf("%s%s", filename, ext)
+	}
+
+	return filepath.Base(filename), ext
+}
+
+func getFilenameFromContentDisposition(headers http.Header) (string, bool) {
+	contentDisposition := headers.Get("Content-Disposition")
+	if contentDisposition == "" {
+		return "", false
+	}
+
+	_, params, err := mime.ParseMediaType(contentDisposition)
+	if err != nil {
+		return "", false
+	}
+
+	filename := params["filename"]
+	if filename == "" {
+		return "", false
+	}
+	filename, _ = url.PathUnescape(filename)
+	return filepath.Base(filename), true
+}
+
 func (r *Repository) sendDownloadCancelledEvent(tId string, url string, downloadMap *result.Map[string, downloadStatus]) {
 	downloadMap.Delete(url)
 
@@ -459,26 +699,4 @@ func (r *Repository) sendDownloadCompletedEvent(tId string, torrentName string, 
 	if err := hook.GlobalHookManager.OnDebridLocalDownloadCompleted().Trigger(event); err != nil {
 		r.logger.Err(err).Str("torrentItemId", tId).Msg("debrid: Failed to trigger local download completed hook")
 	}
-}
-
-func getFilenameFromHeaders(url string) (string, error) {
-	resp, err := http.Head(url)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	// Get the Content-Disposition header
-	contentDisposition := resp.Header.Get("Content-Disposition")
-	if contentDisposition == "" {
-		return "", fmt.Errorf("no Content-Disposition header found")
-	}
-
-	// Use a regex to extract the filename from Content-Disposition
-	re := regexp.MustCompile(`filename="(.+)"`)
-	matches := re.FindStringSubmatch(contentDisposition)
-	if len(matches) > 1 {
-		return matches[1], nil
-	}
-	return "", fmt.Errorf("filename not found in Content-Disposition header")
 }

--- a/internal/debrid/client/download.go
+++ b/internal/debrid/client/download.go
@@ -348,10 +348,14 @@ func (r *Repository) downloadHTTPFile(ctx context.Context, tId string, downloadU
 		appendFile, responseExpectedSize, err := validateDebridDownloadResponse(resp, rangeStart)
 		if err != nil {
 			_ = resp.Body.Close()
-			if errors.Is(err, errInvalidDownloadStatus) || errors.Is(err, errInvalidDownloadContentRange) {
+			if errors.Is(err, errInvalidDownloadContentRange) {
+				return nil, err
+			}
+			if errors.Is(err, errInvalidDownloadStatus) && !isRetryableDebridDownloadStatus(resp.StatusCode) {
 				return nil, err
 			}
 			lastErr = err
+			r.logger.Warn().Err(err).Int("attempt", attempt).Int("status", resp.StatusCode).Str("downloadUrl", downloadUrl).Msg("debrid: Download response status failed, retrying")
 			if err := waitBeforeDebridDownloadRetry(ctx, attempt, backoff); err != nil {
 				return nil, err
 			}
@@ -432,6 +436,19 @@ func (r *Repository) openDownloadResponse(ctx context.Context, client *http.Clie
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", rangeStart))
 	}
 	return client.Do(req)
+}
+
+func isRetryableDebridDownloadStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateDebridDownloadResponse(resp *http.Response, rangeStart int64) (appendFile bool, expectedSize int64, err error) {

--- a/internal/debrid/client/download_test.go
+++ b/internal/debrid/client/download_test.go
@@ -156,6 +156,69 @@ func TestDebridDownloadFileRestartsWhenRangeIgnored(t *testing.T) {
 	require.Equal(t, "restarted", string(content))
 }
 
+func TestDebridDownloadFileRetriesTransientStatusResponses(t *testing.T) {
+	withFastDebridDownloadRetries(t, 2)
+
+	for _, statusCode := range []int{
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	} {
+		t.Run(fmt.Sprintf("status_%d", statusCode), func(t *testing.T) {
+			logger := util.NewLogger()
+			ws := newRecordingWSEventManager(logger)
+			repo := &Repository{logger: logger, wsEventManager: ws}
+			zipBytes := makeDownloadTestZip(t, "episode.txt", "retried")
+			var requests atomic.Int32
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestNumber := requests.Add(1)
+				if requestNumber == 1 {
+					w.WriteHeader(statusCode)
+					_, _ = w.Write([]byte(http.StatusText(statusCode)))
+					return
+				}
+
+				writeZipResponseHeaders(w, len(zipBytes), "")
+				_, _ = w.Write(zipBytes)
+			}))
+			t.Cleanup(server.Close)
+
+			destination := t.TempDir()
+			ok := repo.downloadFile(context.Background(), "torrent-1", server.URL, destination, result.NewMap[string, downloadStatus]())
+
+			require.True(t, ok)
+			require.Equal(t, int32(2), requests.Load())
+			content, err := os.ReadFile(filepath.Join(destination, "episode.txt"))
+			require.NoError(t, err)
+			require.Equal(t, "retried", string(content))
+		})
+	}
+}
+
+func TestDebridDownloadFileFailsFastPermanentStatusResponse(t *testing.T) {
+	withFastDebridDownloadRetries(t, 3)
+
+	logger := util.NewLogger()
+	ws := newRecordingWSEventManager(logger)
+	repo := &Repository{logger: logger, wsEventManager: ws}
+	var requests atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(http.StatusText(http.StatusNotFound)))
+	}))
+	t.Cleanup(server.Close)
+
+	ok := repo.downloadFile(context.Background(), "torrent-1", server.URL, t.TempDir(), result.NewMap[string, downloadStatus]())
+
+	require.False(t, ok)
+	require.Equal(t, int32(1), requests.Load())
+}
+
 func TestDebridDownloadTorrentDoesNotCompleteAfterTruncatedRetries(t *testing.T) {
 	withFastDebridDownloadRetries(t, 3)
 

--- a/internal/debrid/client/download_test.go
+++ b/internal/debrid/client/download_test.go
@@ -1,0 +1,291 @@
+package debrid_client
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"seanime/internal/debrid/debrid"
+	"seanime/internal/events"
+	"seanime/internal/hook"
+	"seanime/internal/hook_resolver"
+	"seanime/internal/util"
+	"seanime/internal/util/result"
+
+	"github.com/rs/zerolog"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingWSEventManager struct {
+	*events.MockWSEventManager
+	mu     sync.Mutex
+	events []events.MockWSEvent
+}
+
+func newRecordingWSEventManager(logger *zerolog.Logger) *recordingWSEventManager {
+	return &recordingWSEventManager{
+		MockWSEventManager: events.NewMockWSEventManager(logger),
+	}
+}
+
+func (m *recordingWSEventManager) SendEvent(t string, payload interface{}) {
+	m.mu.Lock()
+	m.events = append(m.events, events.MockWSEvent{Type: t, Payload: payload})
+	m.mu.Unlock()
+}
+
+func (m *recordingWSEventManager) countDownloadStatus(status string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	count := 0
+	for _, event := range m.events {
+		if event.Type != events.DebridDownloadProgress {
+			continue
+		}
+		payload, ok := event.Payload.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if payload["status"] == status {
+			count++
+		}
+	}
+	return count
+}
+
+func TestDebridDownloadFileFullZipWithContentLength(t *testing.T) {
+	logger := util.NewLogger()
+	ws := newRecordingWSEventManager(logger)
+	repo := &Repository{logger: logger, wsEventManager: ws}
+	zipBytes := makeDownloadTestZip(t, "episode.txt", "complete")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		writeZipResponseHeaders(w, len(zipBytes), "")
+		_, _ = w.Write(zipBytes)
+	}))
+	t.Cleanup(server.Close)
+
+	destination := t.TempDir()
+	ok := repo.downloadFile(context.Background(), "torrent-1", server.URL, destination, result.NewMap[string, downloadStatus]())
+
+	require.True(t, ok)
+	require.FileExists(t, filepath.Join(destination, "episode.txt"))
+	content, err := os.ReadFile(filepath.Join(destination, "episode.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "complete", string(content))
+}
+
+func TestDebridDownloadFileResumesAfterTruncatedResponse(t *testing.T) {
+	withFastDebridDownloadRetries(t, 3)
+
+	logger := util.NewLogger()
+	ws := newRecordingWSEventManager(logger)
+	repo := &Repository{logger: logger, wsEventManager: ws}
+	zipBytes := makeDownloadTestZip(t, "episode.txt", "resumed")
+	splitAt := len(zipBytes) / 2
+	var requests atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestNumber := requests.Add(1)
+		if requestNumber == 1 {
+			writeZipResponseHeaders(w, len(zipBytes), "")
+			_, _ = w.Write(zipBytes[:splitAt])
+			return
+		}
+
+		require.Equal(t, fmt.Sprintf("bytes=%d-", splitAt), r.Header.Get("Range"))
+		writeZipResponseHeaders(w, len(zipBytes)-splitAt, fmt.Sprintf("bytes %d-%d/%d", splitAt, len(zipBytes)-1, len(zipBytes)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(zipBytes[splitAt:])
+	}))
+	t.Cleanup(server.Close)
+
+	destination := t.TempDir()
+	ok := repo.downloadFile(context.Background(), "torrent-1", server.URL, destination, result.NewMap[string, downloadStatus]())
+
+	require.True(t, ok)
+	require.Equal(t, int32(2), requests.Load())
+	content, err := os.ReadFile(filepath.Join(destination, "episode.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "resumed", string(content))
+}
+
+func TestDebridDownloadFileRestartsWhenRangeIgnored(t *testing.T) {
+	withFastDebridDownloadRetries(t, 3)
+
+	logger := util.NewLogger()
+	ws := newRecordingWSEventManager(logger)
+	repo := &Repository{logger: logger, wsEventManager: ws}
+	zipBytes := makeDownloadTestZip(t, "episode.txt", "restarted")
+	splitAt := len(zipBytes) / 2
+	var requests atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestNumber := requests.Add(1)
+		writeZipResponseHeaders(w, len(zipBytes), "")
+		if requestNumber == 1 {
+			_, _ = w.Write(zipBytes[:splitAt])
+			return
+		}
+		require.NotEmpty(t, r.Header.Get("Range"))
+		_, _ = w.Write(zipBytes)
+	}))
+	t.Cleanup(server.Close)
+
+	destination := t.TempDir()
+	ok := repo.downloadFile(context.Background(), "torrent-1", server.URL, destination, result.NewMap[string, downloadStatus]())
+
+	require.True(t, ok)
+	require.Equal(t, int32(2), requests.Load())
+	content, err := os.ReadFile(filepath.Join(destination, "episode.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "restarted", string(content))
+}
+
+func TestDebridDownloadTorrentDoesNotCompleteAfterTruncatedRetries(t *testing.T) {
+	withFastDebridDownloadRetries(t, 3)
+
+	logger := util.NewLogger()
+	ws := newRecordingWSEventManager(logger)
+	zipBytes := makeDownloadTestZip(t, "episode.txt", "truncated")
+	splitAt := len(zipBytes) / 2
+	var requests atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		writeZipResponseHeaders(w, len(zipBytes), "")
+		_, _ = w.Write(zipBytes[:splitAt])
+	}))
+	t.Cleanup(server.Close)
+
+	completed := make(chan struct{}, 1)
+	withDebridDownloadCompletedHook(t, logger, completed)
+	repo := newDownloadTestRepository(logger, ws, server.URL)
+
+	err := repo.downloadTorrentItem("torrent-1", "test torrent", t.TempDir())
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return requests.Load() >= int32(debridDownloadMaxAttempts) && ws.countDownloadStatus("cancelled") > 0
+	}, time.Second, 10*time.Millisecond)
+
+	require.Never(t, func() bool {
+		return ws.countDownloadStatus("completed") > 0 || len(completed) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestDebridDownloadTorrentAggregatesMultiURLFailures(t *testing.T) {
+	withFastDebridDownloadRetries(t, 2)
+
+	logger := util.NewLogger()
+	ws := newRecordingWSEventManager(logger)
+	successZip := makeDownloadTestZip(t, "episode.txt", "success")
+	failedZip := makeDownloadTestZip(t, "failed.txt", "failed")
+	var failedRequests atomic.Int32
+
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeZipResponseHeaders(w, len(successZip), "")
+		_, _ = w.Write(successZip)
+	}))
+	t.Cleanup(successServer.Close)
+
+	failedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		failedRequests.Add(1)
+		writeZipResponseHeaders(w, len(failedZip), "")
+		_, _ = w.Write(failedZip[:len(failedZip)/2])
+	}))
+	t.Cleanup(failedServer.Close)
+
+	completed := make(chan struct{}, 1)
+	withDebridDownloadCompletedHook(t, logger, completed)
+	downloadURL := strings.Join([]string{successServer.URL, failedServer.URL}, ",")
+	repo := newDownloadTestRepository(logger, ws, downloadURL)
+
+	err := repo.downloadTorrentItem("torrent-1", "test torrent", t.TempDir())
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return failedRequests.Load() >= int32(debridDownloadMaxAttempts) && ws.countDownloadStatus("cancelled") > 0
+	}, time.Second, 10*time.Millisecond)
+
+	require.Never(t, func() bool {
+		return ws.countDownloadStatus("completed") > 0 || len(completed) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func makeDownloadTestZip(t *testing.T, name string, content string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create(name)
+	require.NoError(t, err)
+	_, err = w.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func writeZipResponseHeaders(w http.ResponseWriter, contentLength int, contentRange string) {
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Content-Disposition", `attachment; filename="batch.zip"`)
+	w.Header().Set("Content-Length", strconv.Itoa(contentLength))
+	if contentRange != "" {
+		w.Header().Set("Content-Range", contentRange)
+	}
+}
+
+func withFastDebridDownloadRetries(t *testing.T, attempts int) {
+	t.Helper()
+
+	oldAttempts := debridDownloadMaxAttempts
+	oldInitialBackoff := debridDownloadInitialBackoff
+	oldMaxBackoff := debridDownloadMaxBackoff
+	debridDownloadMaxAttempts = attempts
+	debridDownloadInitialBackoff = time.Millisecond
+	debridDownloadMaxBackoff = time.Millisecond
+	t.Cleanup(func() {
+		debridDownloadMaxAttempts = oldAttempts
+		debridDownloadInitialBackoff = oldInitialBackoff
+		debridDownloadMaxBackoff = oldMaxBackoff
+	})
+}
+
+func withDebridDownloadCompletedHook(t *testing.T, logger *zerolog.Logger, completed chan<- struct{}) {
+	t.Helper()
+
+	oldManager := hook.GlobalHookManager
+	manager := hook.NewHookManager(hook.NewHookManagerOptions{Logger: logger})
+	hook.SetGlobalHookManager(manager)
+	t.Cleanup(func() {
+		hook.SetGlobalHookManager(oldManager)
+	})
+
+	manager.OnDebridLocalDownloadCompleted().BindFunc(func(e hook_resolver.Resolver) error {
+		completed <- struct{}{}
+		return e.Next()
+	})
+}
+
+func newDownloadTestRepository(logger *zerolog.Logger, ws events.WSEventManagerInterface, downloadURL string) *Repository {
+	return &Repository{
+		provider: mo.Some[debrid.Provider](&fakeDebridProvider{downloadURL: func(opts debrid.DownloadTorrentOptions) (string, error) {
+			return downloadURL, nil
+		}}),
+		logger:         logger,
+		wsEventManager: ws,
+		ctxMap:         result.NewMap[string, context.CancelFunc](),
+	}
+}

--- a/internal/debrid/client/repository_test.go
+++ b/internal/debrid/client/repository_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 type fakeDebridProvider struct {
-	addTorrent func(opts debrid.AddTorrentOptions) (string, error)
+	addTorrent  func(opts debrid.AddTorrentOptions) (string, error)
+	downloadURL func(opts debrid.DownloadTorrentOptions) (string, error)
 }
 
 func (f *fakeDebridProvider) GetSettings() debrid.Settings {
@@ -40,6 +41,9 @@ func (f *fakeDebridProvider) GetTorrentStreamUrl(ctx context.Context, opts debri
 }
 
 func (f *fakeDebridProvider) GetTorrentDownloadUrl(opts debrid.DownloadTorrentOptions) (string, error) {
+	if f.downloadURL != nil {
+		return f.downloadURL(opts)
+	}
 	return "", nil
 }
 

--- a/internal/util/logger.go
+++ b/internal/util/logger.go
@@ -36,6 +36,14 @@ const (
 var logBuffer bytes.Buffer
 var logBufferMutex = &sync.Mutex{}
 
+type lockedLogBufferWriter struct{}
+
+func (lockedLogBufferWriter) Write(p []byte) (int, error) {
+	logBufferMutex.Lock()
+	defer logBufferMutex.Unlock()
+	return logBuffer.Write(p)
+}
+
 func NewLogger() *zerolog.Logger {
 
 	timeFormat := fmt.Sprintf("%s", time.DateTime)
@@ -53,7 +61,7 @@ func NewLogger() *zerolog.Logger {
 	}
 
 	fileOutput := zerolog.ConsoleWriter{
-		Out:           &logBuffer,
+		Out:           lockedLogBufferWriter{},
 		TimeFormat:    timeFormat,
 		FormatMessage: ZerologFormatMessageSimple,
 		FormatLevel:   ZerologFormatLevelSimple,


### PR DESCRIPTION
## Why

TorBox CDN downloads can drop mid-stream while Seanime is downloading a generated zip archive. When that happened, Seanime could treat the short read as a completed download, then `archive/zip` failed later with `zip: checksum error` because the archive was truncated. This was reproducible on Ubuntu with larger batch downloads around ~1.9 GiB, while smaller single-episode zips completed before the connection dropped.

The storage path was not the root cause: CIFS round-trip tests passed, VPN removal did not change the failure, and manually downloading the same TorBox URL to local `/tmp` also timed out. The fix belongs in the debrid download layer.

## What changed

- Added resumable debrid downloads with retry/backoff.
- Detect incomplete known-size responses by comparing bytes written against `Content-Length` / `Content-Range`.
- Resume interrupted transfers with `Range: bytes=<written>-` when the server supports partial content.
- Restart cleanly when a server ignores range requests and returns a fresh `200 OK`.
- Validate completed zip downloads when the HTTP response does not expose a trustworthy final size, so truncated chunked/no-length zips are retried instead of going straight to extraction failure.
- Retry transient HTTP statuses such as 429 and selected 5xx responses while failing fast for permanent statuses.
- Avoid sending completed events when any URL in a multi-file debrid download fails.
- Protect the shared logger buffer writer with the existing mutex to avoid concurrent writes during parallel download logging.

## Validation

- `go test -count=1 ./internal/debrid/client`
- `go test -count=1 ./internal/debrid/...`
- `git diff --check origin/main...HEAD`

## Notes

This should fix the TorBox issue when the CDN supports HTTP range requests. If TorBox returns `200 OK` for range requests or repeatedly cuts the same connection before completion, Seanime will now fail cleanly after retries instead of reporting completion and surfacing `zip: checksum error` during extraction.
