### PR TITLE
fix(webui): resolve YouTube trailers for chromium browsers

### DIFF
--- a/seanime-web/src/app/(main)/_features/anime/_components/trailer-modal.tsx
+++ b/seanime-web/src/app/(main)/_features/anime/_components/trailer-modal.tsx
@@ -63,6 +63,7 @@ export function Content(props: ContentProps) {
             >
                 {__isElectronDesktop__ && <ElectronYoutubeEmbed trailerId={trailerId} />}
                 {!__isElectronDesktop__ && <iframe
+                    {...({ credentialless: "true" } as any)}
                     src={`https://www.youtube.com/embed/${trailerId}`}
                     title="YouTube Video"
                     className="w-full aspect-video rounded-xl"


### PR DESCRIPTION
Adds the credentialless attribute to the trailer modal’s iframe.
This fixes the trailer failing to load under COEP.