### PR TITLE
fix(webui): resolve discover header trailer playback for chromium

### DIFF
--- a/seanime-web/src/app/(main)/discover/_components/discover-page-header.tsx
+++ b/seanime-web/src/app/(main)/discover/_components/discover-page-header.tsx
@@ -178,6 +178,7 @@ function BannerImage({ media, isTransitioning, shouldBlurBanner, showTrailer, tr
                         />
                     </motion.div>}
                     {!__isElectronDesktop__ && <MotionIframe
+                        {...({ credentialless: "true" } as any)}
                         src={`https://www.youtube-nocookie.com/embed/${trailerId}?autoplay=1&controls=0&mute=1&disablekb=1&loop=1&vq=medium&playlist=${trailerId}&cc_lang_pref=ja&enablejsapi=true`}
                         className="w-full h-full absolute left-0 object-cover object-center lg:scale-[1.8] 2xl:scale-[2.5]"
                         allow="autoplay"
@@ -310,8 +311,8 @@ function MediaMetadata({ media, pageType, isTransitioning, onHoverChange }: Medi
                             {(media as AL_BaseAnime).nextAiringEpisode?.episode ? (
                                 <span>
                                     {(media as AL_BaseAnime).nextAiringEpisode?.episode! - 1} episode{(media as AL_BaseAnime).nextAiringEpisode?.episode! - 1 === 1
-                                    ? ""
-                                    : "s"} released
+                                        ? ""
+                                        : "s"} released
                                 </span>
                             ) : (
                                 <span>


### PR DESCRIPTION
Includes the `credentialless` attribute to the trailer iframe