### PR TITLE
feat: add Docker and docker-compose support for self-hosting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+seanime-denshi/
+seanime-web/node_modules/
+seanime-web/out/
+seanime-web/out-denshi/
+web/
+test/
+*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,9 @@ testdata/
 */.DS_Store
 .todo/
 
-Dockerfile
 Dockerfile.dev
 dev.dockerfile
-.dockerignore
+.dockerignore.local
 
 go.work
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:24-alpine AS frontend
+WORKDIR /build
+COPY seanime-web/package*.json ./
+RUN npm ci
+COPY seanime-web/ .
+RUN npm run build
+
+FROM golang:1.26-alpine AS builder
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=frontend /build/out ./web/
+RUN CGO_ENABLED=0 go build -o seanime -trimpath -ldflags="-s -w"
+
+FROM alpine:3.23
+RUN apk add --no-cache ca-certificates ffmpeg
+WORKDIR /app
+COPY --from=builder /build/seanime .
+EXPOSE 43211
+VOLUME /data
+ENTRYPOINT ["/app/seanime"]
+CMD ["--datadir", "/data", "--host", "0.0.0.0", "--port", "43211"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  seanime:
+    build: .
+    ports:
+      - "43211:43211"
+    volumes:
+      - seanime-data:/data
+      # Mount your media library (adjust path as needed):
+      # - /path/to/media:/media
+    restart: unless-stopped
+
+volumes:
+  seanime-data:


### PR DESCRIPTION
## Summary

- Adds a multi-stage `Dockerfile` that builds the React frontend and embeds it into a static Go binary
- Adds `docker-compose.yml` for a minimal self-hosting setup
- Adds `.dockerignore` to keep the build context lean
- Updates `.gitignore` to un-ignore `Dockerfile` and `.dockerignore`

## Build stages

1. **frontend** (`node:24-alpine`): runs `npm run build` in `seanime-web/`, outputs to `out/`
2. **builder** (`golang:1.26-alpine`): copies frontend output to `web/` (satisfies `//go:embed all:web`), builds a fully static binary with `CGO_ENABLED=0` (works because the project uses `modernc.org/sqlite`)
3. **runtime** (`alpine:3.23`): minimal image with `ffmpeg` and `ca-certificates`; default `--host` is overridden to `0.0.0.0`

## Usage

```sh
# Build and start
docker compose up -d

# Mount your media library by uncommenting the volume line in docker-compose.yml
```

Data is persisted in a named Docker volume at `/data`.