### PR TITLE
Fix StartupWMClass mismatch for Gear Lever installs on GNOME

### DIFF
--- a/seanime-denshi/package.json
+++ b/seanime-denshi/package.json
@@ -87,7 +87,10 @@
         }
       ],
       "category": "Entertainment",
-      "artifactName": "seanime-denshi-${version}_Linux_${arch}.${ext}"
+      "artifactName": "seanime-denshi-${version}_Linux_${arch}.${ext}",
+      "desktop": {
+        "StartupWMClass": "seanime-denshi"
+      }
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
Updated the electron-builder config to set the correct StartupWMClass for the Linux build. This should resolve the issue where the app icon and window grouping were mismatched when installing Seanime Denshi using Gear Lever on GNOME desktops.
Currently the App shows up like this:
<img width="186" height="130" alt="image" src="https://github.com/user-attachments/assets/53207c4c-7ad7-42e1-903d-28260984b45f" />
With the correct StartupWMClass it shows up like this:
<img width="153" height="141" alt="image" src="https://github.com/user-attachments/assets/c8afc4a9-6514-4b49-bfc0-e250db15ba9f" />
