### PR TITLE
 Fill missing Previews in cache in SearchAnime()

### DIFF
--- a/DEVELOPMENT_AND_BUILD.md
+++ b/DEVELOPMENT_AND_BUILD.md
@@ -83,9 +83,9 @@ For development, you should be familiar with both Go and React.
    ```bash
    go run main.go --datadir="path/to/datadir"
    ```
-   
+
 	- This will generate all the files needed in the `path/to/datadir` directory.
-   
+
 3. **Configure the development server**:
    - Change the port in the `config.toml` located in the development data directory to `43000`. The web interface will connect to this port during development. Change the host to `0.0.0.0` to allow connections from other devices.
    - Re-run the server with the updated configuration.
@@ -120,7 +120,7 @@ The Next.js development environment is configured such that all requests are mad
 
 The backend follows a well-defined structure:
 
-1. **Routes Declaration**: 
+1. **Routes Declaration**:
    - All routes are registered in `internal/handlers/routes.go`
    - Each route is associated with a specific handler method
 
@@ -209,15 +209,15 @@ AniList mock fixtures are read-only during normal test runs. Set `SEANIME_TEST_R
 To avoid remembering the environment variable and basic auth checks, use the refresh wrapper:
 
 ```bash
-go run ./scripts/record_anilist_fixtures
+go run ./codegen/record_anilist_fixtures
 ```
 
 Notes:
 
 - It validates that `test/config.toml` exists, `flags.enable_anilist_tests=true`, and `provider.anilist_jwt` is set.
 - It defaults to refreshing `./internal/api/anilist` and sets `SEANIME_TEST_RECORD_ANILIST_FIXTURES=true` for the test process.
-- Pass packages to widen the refresh scope, for example `go run ./scripts/record_anilist_fixtures ./internal/api/anilist ./internal/library/scanner`.
-- Pass `-run` to target specific live refresh tests, for example `go run ./scripts/record_anilist_fixtures -run 'TestGetAnimeByIdLive|TestBaseAnime_FetchMediaTree_BaseAnimeLive'`.
+- Pass packages to widen the refresh scope, for example `go run ./codegen/record_anilist_fixtures ./internal/api/anilist ./internal/library/scanner`.
+- Pass `-run` to target specific live refresh tests, for example `go run ./codegen/record_anilist_fixtures -run 'TestGetAnimeByIdLive|TestBaseAnime_FetchMediaTree_BaseAnimeLive'`.
 
 #### Testing with Third-Party Apps
 

--- a/internal/torrents/torrent/repository.go
+++ b/internal/torrents/torrent/repository.go
@@ -13,13 +13,12 @@ import (
 
 type (
 	Repository struct {
-		logger                         *zerolog.Logger
-		extensionBankRef               *util.Ref[*extension.UnifiedBank]
-		animeProviderSearchCaches      *result.Map[string, *result.Cache[string, *SearchData]]
-		animeProviderSmartSearchCaches *result.Map[string, *result.Cache[string, *SearchData]]
-		settings                       RepositorySettings
-		metadataProviderRef            *util.Ref[metadata_provider.Provider]
-		mu                             sync.Mutex
+		logger                    *zerolog.Logger
+		extensionBankRef          *util.Ref[*extension.UnifiedBank]
+		animeProviderSearchCaches *result.Map[string, *result.Cache[string, *SearchData]]
+		settings                  RepositorySettings
+		metadataProviderRef       *util.Ref[metadata_provider.Provider]
+		mu                        sync.Mutex
 	}
 
 	RepositorySettings struct {
@@ -36,13 +35,12 @@ type NewRepositoryOptions struct {
 
 func NewRepository(opts *NewRepositoryOptions) *Repository {
 	ret := &Repository{
-		logger:                         opts.Logger,
-		metadataProviderRef:            opts.MetadataProviderRef,
-		extensionBankRef:               opts.ExtensionBankRef,
-		animeProviderSearchCaches:      result.NewMap[string, *result.Cache[string, *SearchData]](),
-		animeProviderSmartSearchCaches: result.NewMap[string, *result.Cache[string, *SearchData]](),
-		settings:                       RepositorySettings{},
-		mu:                             sync.Mutex{},
+		logger:                    opts.Logger,
+		metadataProviderRef:       opts.MetadataProviderRef,
+		extensionBankRef:          opts.ExtensionBankRef,
+		animeProviderSearchCaches: result.NewMap[string, *result.Cache[string, *SearchData]](),
+		settings:                  RepositorySettings{},
+		mu:                        sync.Mutex{},
 	}
 
 	sub := ret.extensionBankRef.Get().Subscribe("torrent-repository")
@@ -71,13 +69,11 @@ func (r *Repository) OnExtensionReloaded() {
 func (r *Repository) reloadExtensions() {
 	// Clear the search caches
 	r.animeProviderSearchCaches = result.NewMap[string, *result.Cache[string, *SearchData]]()
-	r.animeProviderSmartSearchCaches = result.NewMap[string, *result.Cache[string, *SearchData]]()
 
 	go func() {
 		// Create new caches for each provider
 		extension.RangeExtensions(r.extensionBankRef.Get(), func(provider string, value extension.AnimeTorrentProviderExtension) bool {
 			r.animeProviderSearchCaches.Set(provider, result.NewCache[string, *SearchData]())
-			r.animeProviderSmartSearchCaches.Set(provider, result.NewCache[string, *SearchData]())
 			return true
 		})
 	}()

--- a/internal/torrents/torrent/search.go
+++ b/internal/torrents/torrent/search.go
@@ -147,9 +147,9 @@ func (r *Repository) SearchAnime(ctx context.Context, opts AnimeSearchOptions) (
 		searchCacheKey = fmt.Sprintf("s%d-%s", opts.Media.GetID(), opts.Query)
 	}
 
-	providerCache := getAnimeSearchCache(r.animeProviderSearchCaches, providerCacheKey)
+	cache := getAnimeSearchCache(r.animeProviderSearchCaches, providerCacheKey)
 	// Check the cache
-	ret, cacheHit := providerCache.Get(searchCacheKey)
+	ret, cacheHit := cache.Get(searchCacheKey)
 	if cacheHit {
 		r.logger.Debug().Str("provider", providerCacheKey).Str("type", string(opts.Type)).Msg("torrent search: Cache HIT")
 	} else {
@@ -395,6 +395,12 @@ func (r *Repository) SearchAnime(ctx context.Context, opts AnimeSearchOptions) (
 		})
 
 		ret.Previews = previews
+
+		if cacheHit {
+			// Update the data in the cache with Previews
+			cache := getAnimeSearchCache(r.animeProviderSearchCaches, providerCacheKey)
+			cache.Set(searchCacheKey, ret)
+		}
 	}
 
 	if !cacheHit {
@@ -408,8 +414,8 @@ func (r *Repository) SearchAnime(ctx context.Context, opts AnimeSearchOptions) (
 			sortSearchData(ret)
 		}
 
-		// Store the data in the cache
-		providerCache.Set(searchCacheKey, ret)
+		cache := getAnimeSearchCache(r.animeProviderSearchCaches, providerCacheKey)
+		cache.Set(searchCacheKey, ret)
 	}
 
 	return

--- a/internal/torrents/torrent/search.go
+++ b/internal/torrents/torrent/search.go
@@ -76,7 +76,6 @@ type (
 
 func (r *Repository) SearchAnime(ctx context.Context, opts AnimeSearchOptions) (ret *SearchData, retErr error) {
 	defer util.HandlePanicInModuleWithError("torrents/torrent/SearchAnime", &retErr)
-	var torrents []*hibiketorrent.AnimeTorrent
 
 	requestedEvent := &TorrentSearchRequestedEvent{Options: opts}
 	_ = hook.GlobalHookManager.OnTorrentSearchRequested().Trigger(requestedEvent)
@@ -140,203 +139,215 @@ func (r *Repository) SearchAnime(ctx context.Context, opts AnimeSearchOptions) (
 		},
 	}
 
-	smartQueryKey := fmt.Sprintf("%d-%s-%d-%s-%t-%t", opts.Media.GetID(), opts.Query, opts.EpisodeNumber, opts.Resolution, opts.BestReleases, opts.Batch)
-	simpleQueryKey := fmt.Sprintf("%d-%s", opts.Media.GetID(), opts.Query)
-
-	if opts.Type == AnimeSearchTypeSmart {
-		cache := getAnimeSearchCache(r.animeProviderSmartSearchCaches, providerCacheKey)
-		// Check the cache
-		data, found := cache.Get(smartQueryKey)
-		if found {
-			r.logger.Debug().Str("provider", providerCacheKey).Str("type", string(opts.Type)).Msg("torrent search: Cache HIT")
-			return data, nil
-		}
-	} else if opts.Type == AnimeSearchTypeSimple {
-		cache := getAnimeSearchCache(r.animeProviderSearchCaches, providerCacheKey)
-		// Check the cache
-		data, found := cache.Get(simpleQueryKey)
-		if found {
-			r.logger.Debug().Str("provider", providerCacheKey).Str("type", string(opts.Type)).Msg("torrent search: Cache HIT")
-			return data, nil
-		}
+	var searchCacheKey string
+	switch opts.Type {
+	case AnimeSearchTypeSmart:
+		searchCacheKey = fmt.Sprintf("m%d-%s-%d-%s-%t-%t", opts.Media.GetID(), opts.Query, opts.EpisodeNumber, opts.Resolution, opts.BestReleases, opts.Batch)
+	case AnimeSearchTypeSimple:
+		searchCacheKey = fmt.Sprintf("s%d-%s", opts.Media.GetID(), opts.Query)
 	}
 
-	anidbAID := 0
-	anidbEID := 0
-	if animeMetadata.IsPresent() {
-		queryMedia.AbsoluteSeasonOffset = animeMetadata.MustGet().GetOffset()
+	providerCache := getAnimeSearchCache(r.animeProviderSearchCaches, providerCacheKey)
+	// Check the cache
+	ret, cacheHit := providerCache.Get(searchCacheKey)
+	if cacheHit {
+		r.logger.Debug().Str("provider", providerCacheKey).Str("type", string(opts.Type)).Msg("torrent search: Cache HIT")
+	} else {
+		var torrents []*hibiketorrent.AnimeTorrent
+		anidbAID := 0
+		anidbEID := 0
+		if animeMetadata.IsPresent() {
+			queryMedia.AbsoluteSeasonOffset = animeMetadata.MustGet().GetOffset()
 
-		if animeMetadata.MustGet().GetMappings() != nil {
-			anidbAID = animeMetadata.MustGet().GetMappings().AnidbId
-			episodeMetadata, found := animeMetadata.MustGet().FindEpisode(strconv.Itoa(opts.EpisodeNumber))
-			if found {
-				anidbEID = episodeMetadata.AnidbEid
-			}
-		}
-	}
-
-	wg := sync.WaitGroup{}
-	wg.Add(len(providers))
-	providerResults := make([][]*hibiketorrent.AnimeTorrent, len(providers))
-	providerErrors := make([]error, len(providers))
-	for i, provider := range providers {
-		go func(i int, provider extension.AnimeTorrentProviderExtension) {
-			defer util.HandlePanicInModuleThen("torrents/torrent/SearchAnime", func() {})
-			defer wg.Done()
-
-			isMain := i == 0
-			r.logger.Debug().Str("provider", provider.GetID()).Str("type", string(opts.Type)).Str("query", opts.Query).Msg("torrent search: Searching for anime torrents")
-
-			canSmartSearch := provider.GetProvider().GetSettings().CanSmartSearch
-			searchType := opts.Type
-			query := opts.Query
-			if isMain && opts.Type == AnimeSearchTypeSmart && !canSmartSearch {
-				providerErrors[i] = fmt.Errorf("provider %s does not support smart search", provider.GetID())
-				return
-			}
-			if !isMain && opts.Type == AnimeSearchTypeSmart && !canSmartSearch {
-				searchType = AnimeSearchTypeSimple
-			}
-			if searchType == AnimeSearchTypeSimple && opts.Query == "" {
-				query = util.CleanMediaTitle(opts.Media.GetRomajiTitleSafe())
-			}
-
-			//// Force simple search if Animap media is absent
-			//if opts.Type == AnimeSearchTypeSmart && animeMetadata.IsAbsent() {
-			//	opts.Type = AnimeSearchTypeSimple
-			//}
-
-			switch searchType {
-			case AnimeSearchTypeSmart:
-				// Check for context cancellation before making the request
-				select {
-				case <-ctx.Done():
-					return
-				default:
+			if animeMetadata.MustGet().GetMappings() != nil {
+				anidbAID = animeMetadata.MustGet().GetMappings().AnidbId
+				episodeMetadata, found := animeMetadata.MustGet().FindEpisode(strconv.Itoa(opts.EpisodeNumber))
+				if found {
+					anidbEID = episodeMetadata.AnidbEid
 				}
+			}
+		}
 
-				res, err := provider.GetProvider().SmartSearch(hibiketorrent.AnimeSmartSearchOptions{
-					Media:         queryMedia,
-					Query:         opts.Query,
-					Batch:         opts.Batch,
-					EpisodeNumber: opts.EpisodeNumber,
-					Resolution:    opts.Resolution,
-					AnidbAID:      anidbAID,
-					AnidbEID:      anidbEID,
-					BestReleases:  opts.BestReleases,
-				})
-				if err != nil {
-					providerErrors[i] = err
+		wg := sync.WaitGroup{}
+		wg.Add(len(providers))
+		providerResults := make([][]*hibiketorrent.AnimeTorrent, len(providers))
+		providerErrors := make([]error, len(providers))
+		for i, provider := range providers {
+			go func(i int, provider extension.AnimeTorrentProviderExtension) {
+				defer util.HandlePanicInModuleThen("torrents/torrent/SearchAnime", func() {})
+				defer wg.Done()
+
+				isMain := i == 0
+				r.logger.Debug().Str("provider", provider.GetID()).Str("type", string(opts.Type)).Str("query", opts.Query).Msg("torrent search: Searching for anime torrents")
+
+				canSmartSearch := provider.GetProvider().GetSettings().CanSmartSearch
+				searchType := opts.Type
+				query := opts.Query
+				if isMain && opts.Type == AnimeSearchTypeSmart && !canSmartSearch {
+					providerErrors[i] = fmt.Errorf("provider %s does not support smart search", provider.GetID())
 					return
 				}
-
-				r.logger.Debug().Str("provider", provider.GetID()).Int("found", len(res)).Msg("torrent search: Found torrents")
-				providerResults[i] = res
-
-				return
-			case AnimeSearchTypeSimple:
-
-				// Check for context cancellation before making the request
-				select {
-				case <-ctx.Done():
-					return
-				default:
+				if !isMain && opts.Type == AnimeSearchTypeSmart && !canSmartSearch {
+					searchType = AnimeSearchTypeSimple
+				}
+				if searchType == AnimeSearchTypeSimple && opts.Query == "" {
+					query = util.CleanMediaTitle(opts.Media.GetRomajiTitleSafe())
 				}
 
-				res, err := provider.GetProvider().Search(hibiketorrent.AnimeSearchOptions{
-					Media: queryMedia,
-					Query: query,
-				})
-				if err != nil {
-					providerErrors[i] = err
-					return
-				}
+				//// Force simple search if Animap media is absent
+				//if opts.Type == AnimeSearchTypeSmart && animeMetadata.IsAbsent() {
+				//	opts.Type = AnimeSearchTypeSimple
+				//}
 
-				r.logger.Debug().Str("provider", provider.GetID()).Int("found", len(res)).Msg("torrent search: Found torrents")
-				providerResults[i] = res
-
-				return
-			}
-
-		}(i, provider)
-	}
-	wg.Wait()
-
-	if providerErrors[0] != nil {
-		return nil, providerErrors[0]
-	}
-
-	for i, res := range providerResults {
-		for _, t := range res {
-			if t == nil {
-				continue
-			}
-			if t.Provider == "" {
-				t.Provider = providers[i].GetID()
-			}
-			torrents = append(torrents, t)
-		}
-	}
-
-	// Place best torrents on top, deduplicate
-	bestReleases := make([]*hibiketorrent.AnimeTorrent, 0)
-	other := make([]*hibiketorrent.AnimeTorrent, 0)
-	for _, t := range torrents {
-		if t.InfoHash == "" { // make sure it's never empty
-			t.InfoHash = t.Name
-		}
-		if t.IsBestRelease {
-			bestReleases = append(bestReleases, t)
-		} else {
-			other = append(other, t)
-		}
-	}
-	torrents = append(bestReleases, other...)
-
-	torrents = lo.UniqBy(torrents, func(t *hibiketorrent.AnimeTorrent) string {
-		return t.InfoHash
-	})
-
-	// Parse all torrents
-	torrentMetadata := make(map[string]*TorrentMetadata)
-	wg.Add(len(torrents))
-	mu := sync.Mutex{}
-	for _, t := range torrents {
-		go func(t *hibiketorrent.AnimeTorrent) {
-			defer wg.Done()
-			tMetadata, found := metadataCache.Get(t.Name)
-			if !found {
-				m := habari.Parse(t.Name)
-				var distance *comparison.LevenshteinResult
-				distance, ok := comparison.FindBestMatchWithLevenshtein(&m.Title, opts.Media.GetAllTitles())
-				if !ok {
-					distance = &comparison.LevenshteinResult{
-						Distance: 1000,
+				switch searchType {
+				case AnimeSearchTypeSmart:
+					// Check for context cancellation before making the request
+					select {
+					case <-ctx.Done():
+						return
+					default:
 					}
+
+					res, err := provider.GetProvider().SmartSearch(hibiketorrent.AnimeSmartSearchOptions{
+						Media:         queryMedia,
+						Query:         opts.Query,
+						Batch:         opts.Batch,
+						EpisodeNumber: opts.EpisodeNumber,
+						Resolution:    opts.Resolution,
+						AnidbAID:      anidbAID,
+						AnidbEID:      anidbEID,
+						BestReleases:  opts.BestReleases,
+					})
+					if err != nil {
+						providerErrors[i] = err
+						return
+					}
+
+					r.logger.Debug().Str("provider", provider.GetID()).Int("found", len(res)).Msg("torrent search: Found torrents")
+					providerResults[i] = res
+
+					return
+				case AnimeSearchTypeSimple:
+
+					// Check for context cancellation before making the request
+					select {
+					case <-ctx.Done():
+						return
+					default:
+					}
+
+					res, err := provider.GetProvider().Search(hibiketorrent.AnimeSearchOptions{
+						Media: queryMedia,
+						Query: query,
+					})
+					if err != nil {
+						providerErrors[i] = err
+						return
+					}
+
+					r.logger.Debug().Str("provider", provider.GetID()).Int("found", len(res)).Msg("torrent search: Found torrents")
+					providerResults[i] = res
+
+					return
 				}
-				tMetadata = &TorrentMetadata{
-					Distance: distance.Distance,
-					Metadata: m,
+
+			}(i, provider)
+		}
+		wg.Wait()
+
+		if providerErrors[0] != nil {
+			return nil, providerErrors[0]
+		}
+
+		for i, res := range providerResults {
+			for _, t := range res {
+				if t == nil {
+					continue
 				}
-				metadataCache.Set(t.Name, tMetadata)
+				if t.Provider == "" {
+					t.Provider = providers[i].GetID()
+				}
+				torrents = append(torrents, t)
 			}
-			mu.Lock()
-			torrentMetadata[t.InfoHash] = tMetadata
-			mu.Unlock()
-		}(t)
+		}
+
+		// Place best torrents on top, deduplicate
+		bestReleases := make([]*hibiketorrent.AnimeTorrent, 0)
+		other := make([]*hibiketorrent.AnimeTorrent, 0)
+		for _, t := range torrents {
+			if t.InfoHash == "" { // make sure it's never empty
+				t.InfoHash = t.Name
+			}
+			if t.IsBestRelease {
+				bestReleases = append(bestReleases, t)
+			} else {
+				other = append(other, t)
+			}
+		}
+		torrents = append(bestReleases, other...)
+
+		torrents = lo.UniqBy(torrents, func(t *hibiketorrent.AnimeTorrent) string {
+			return t.InfoHash
+		})
+
+		// Parse all torrents
+		torrentMetadata := make(map[string]*TorrentMetadata)
+		wg.Add(len(torrents))
+		mu := sync.Mutex{}
+		for _, t := range torrents {
+			go func(t *hibiketorrent.AnimeTorrent) {
+				defer wg.Done()
+				tMetadata, found := metadataCache.Get(t.Name)
+				if !found {
+					m := habari.Parse(t.Name)
+					var distance *comparison.LevenshteinResult
+					distance, ok := comparison.FindBestMatchWithLevenshtein(&m.Title, opts.Media.GetAllTitles())
+					if !ok {
+						distance = &comparison.LevenshteinResult{
+							Distance: 1000,
+						}
+					}
+					tMetadata = &TorrentMetadata{
+						Distance: distance.Distance,
+						Metadata: m,
+					}
+					metadataCache.Set(t.Name, tMetadata)
+				}
+				mu.Lock()
+				torrentMetadata[t.InfoHash] = tMetadata
+				mu.Unlock()
+			}(t)
+		}
+		wg.Wait()
+
+		// sort by seeders, put best releases on top
+		slices.SortFunc(torrents, func(i, j *hibiketorrent.AnimeTorrent) int {
+			if i.IsBestRelease != j.IsBestRelease {
+				if i.IsBestRelease {
+					return -1
+				}
+				return 1
+			}
+			return cmp.Compare(j.Seeders, i.Seeders)
+		})
+
+		ret = &SearchData{
+			Torrents:                 torrents,
+			TorrentMetadata:          torrentMetadata,
+			IncludedSpecialProviders: includedProviderIds,
+			AnimeMetadata:            animeMetadata.OrEmpty(),
+		}
 	}
-	wg.Wait()
 
 	//
 	// Previews
 	//
-	previews := make([]*Preview, 0)
-
-	if opts.Type == AnimeSearchTypeSmart && !opts.SkipPreviews {
+	if len(ret.Previews) == 0 && opts.Type == AnimeSearchTypeSmart && !opts.SkipPreviews {
+		var previews []*Preview
 		wg := sync.WaitGroup{}
-		wg.Add(len(torrents))
+		wg.Add(len(ret.Torrents))
 		mu := sync.Mutex{}
-		for _, t := range torrents {
+		for _, t := range ret.Torrents {
 			go func(t *hibiketorrent.AnimeTorrent) {
 				defer wg.Done()
 
@@ -368,60 +379,37 @@ func (r *Repository) SearchAnime(ctx context.Context, opts AnimeSearchOptions) (
 			return nil, ctx.Err()
 		default:
 		}
-	}
 
-	// sort both by seeders, put best releases on top
-	slices.SortFunc(torrents, func(i, j *hibiketorrent.AnimeTorrent) int {
-		if i.IsBestRelease != j.IsBestRelease {
-			if i.IsBestRelease {
-				return -1
+		// sort by seeders, put best releases on top
+		previews = lo.Filter(previews, func(p *Preview, _ int) bool {
+			return p != nil && p.Torrent != nil
+		})
+		slices.SortFunc(previews, func(i, j *Preview) int {
+			if i.Torrent.IsBestRelease != j.Torrent.IsBestRelease {
+				if i.Torrent.IsBestRelease {
+					return -1
+				}
+				return 1
 			}
-			return 1
+			return cmp.Compare(j.Torrent.Seeders, i.Torrent.Seeders)
+		})
+
+		ret.Previews = previews
+	}
+
+	if !cacheHit {
+		searchEvent := &TorrentSearchEvent{
+			Options:    opts,
+			SearchData: ret,
 		}
-		return cmp.Compare(j.Seeders, i.Seeders)
-	})
-	previews = lo.Filter(previews, func(p *Preview, _ int) bool {
-		return p != nil && p.Torrent != nil
-	})
-	slices.SortFunc(previews, func(i, j *Preview) int {
-		if i.Torrent.IsBestRelease != j.Torrent.IsBestRelease {
-			if i.Torrent.IsBestRelease {
-				return -1
-			}
-			return 1
+		_ = hook.GlobalHookManager.OnTorrentSearch().Trigger(searchEvent)
+		if searchEvent.SearchData != nil {
+			ret = searchEvent.SearchData
+			sortSearchData(ret)
 		}
-		return cmp.Compare(j.Torrent.Seeders, i.Torrent.Seeders)
-	})
 
-	ret = &SearchData{
-		Torrents:                 torrents,
-		Previews:                 previews,
-		TorrentMetadata:          torrentMetadata,
-		IncludedSpecialProviders: includedProviderIds,
-	}
-
-	if animeMetadata.IsPresent() {
-		ret.AnimeMetadata = animeMetadata.MustGet()
-	}
-
-	searchEvent := &TorrentSearchEvent{
-		Options:    opts,
-		SearchData: ret,
-	}
-	_ = hook.GlobalHookManager.OnTorrentSearch().Trigger(searchEvent)
-	if searchEvent.SearchData != nil {
-		ret = searchEvent.SearchData
-	}
-	sortSearchData(ret)
-
-	// Store the data in the cache
-	switch opts.Type {
-	case AnimeSearchTypeSmart:
-		cache := getAnimeSearchCache(r.animeProviderSmartSearchCaches, providerCacheKey)
-		cache.Set(smartQueryKey, ret)
-	case AnimeSearchTypeSimple:
-		cache := getAnimeSearchCache(r.animeProviderSearchCaches, providerCacheKey)
-		cache.Set(simpleQueryKey, ret)
+		// Store the data in the cache
+		providerCache.Set(searchCacheKey, ret)
 	}
 
 	return
@@ -485,6 +473,7 @@ func sortSearchData(data *SearchData) {
 		return
 	}
 
+	// sort both by seeders, put best releases on top
 	slices.SortFunc(data.Torrents, func(i, j *hibiketorrent.AnimeTorrent) int {
 		if i.IsBestRelease != j.IsBestRelease {
 			if i.IsBestRelease {

--- a/internal/torrents/torrent/search.go
+++ b/internal/torrents/torrent/search.go
@@ -394,10 +394,13 @@ func (r *Repository) SearchAnime(ctx context.Context, opts AnimeSearchOptions) (
 			return cmp.Compare(j.Torrent.Seeders, i.Torrent.Seeders)
 		})
 
-		ret.Previews = previews
-
-		if cacheHit {
-			// Update the data in the cache with Previews
+		if !cacheHit {
+			ret.Previews = previews
+		} else {
+			// `ret` is stored in cache by pointer and cannot be modified in-place
+			tmp := *ret
+			ret = &tmp
+			ret.Previews = previews
 			cache := getAnimeSearchCache(r.animeProviderSearchCaches, providerCacheKey)
 			cache.Set(searchCacheKey, ret)
 		}


### PR DESCRIPTION
Fixes #825

I kept the behaviour that TorrentSearch event is triggered only once. Meaning, if SearchAnime is first called with `opts.SkipPreviews = true`, then TorrentSearch will be called with empty `SearchData.Previews`. When SearchAnime is called again with `opts.SkipPreviews = false`, previews will be computed, and the cache entry will be updated, but TorrentSearch won't be called again.

I replaced `animeProviderSearchCaches` and `animeProviderSmartSearchCaches` with combined `animeProviderSearchCaches`. The way cache keys are constructed ensures they are different for smart vs simple search.