### PR TITLE
Fix missing error handling in SmartSearch and Search

### DIFF
--- a/internal/extension_repo/goja_anime_torrent_provider.go
+++ b/internal/extension_repo/goja_anime_torrent_provider.go
@@ -30,14 +30,12 @@ func NewGojaAnimeTorrentProvider(ext *extension.Extension, language extension.La
 func (g *GojaAnimeTorrentProvider) Search(opts hibiketorrent.AnimeSearchOptions) (ret []*hibiketorrent.AnimeTorrent, err error) {
 	defer util.HandlePanicInModuleWithError(g.ext.ID+".Search", &err)
 
-	method, err := g.callClassMethod(context.Background(), "search", structToMap(opts))
-
-	promiseRes, err := g.waitForPromise(method)
+	res, err := g.callClassMethod(context.Background(), "search", structToMap(opts))
 	if err != nil {
 		return nil, err
 	}
 
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -52,14 +50,12 @@ func (g *GojaAnimeTorrentProvider) Search(opts hibiketorrent.AnimeSearchOptions)
 func (g *GojaAnimeTorrentProvider) SmartSearch(opts hibiketorrent.AnimeSmartSearchOptions) (ret []*hibiketorrent.AnimeTorrent, err error) {
 	defer util.HandlePanicInModuleWithError(g.ext.ID+".SmartSearch", &err)
 
-	method, err := g.callClassMethod(context.Background(), "smartSearch", structToMap(opts))
-
-	promiseRes, err := g.waitForPromise(method)
+	res, err := g.callClassMethod(context.Background(), "smartSearch", structToMap(opts))
 	if err != nil {
 		return nil, err
 	}
 
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -79,12 +75,7 @@ func (g *GojaAnimeTorrentProvider) GetTorrentInfoHash(torrent *hibiketorrent.Ani
 		return "", err
 	}
 
-	promiseRes, err := g.waitForPromise(res)
-	if err != nil {
-		return "", err
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return "", err
 	}
@@ -100,12 +91,7 @@ func (g *GojaAnimeTorrentProvider) GetTorrentMagnetLink(torrent *hibiketorrent.A
 		return "", err
 	}
 
-	promiseRes, err := g.waitForPromise(res)
-	if err != nil {
-		return "", err
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return "", err
 	}
@@ -116,17 +102,12 @@ func (g *GojaAnimeTorrentProvider) GetTorrentMagnetLink(torrent *hibiketorrent.A
 func (g *GojaAnimeTorrentProvider) GetLatest() (ret []*hibiketorrent.AnimeTorrent, err error) {
 	defer util.HandlePanicInModuleWithError(g.ext.ID+".GetLatest", &err)
 
-	method, err := g.callClassMethod(context.Background(), "getLatest")
+	res, err := g.callClassMethod(context.Background(), "getLatest")
 	if err != nil {
 		return nil, err
 	}
 
-	promiseRes, err := g.waitForPromise(method)
-	if err != nil {
-		return nil, err
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/extension_repo/goja_custom_source.go
+++ b/internal/extension_repo/goja_custom_source.go
@@ -42,17 +42,12 @@ func (g *GojaCustomSource) ListAnime(ctx context.Context, search string, page in
 
 	g.logger.Debug().Str("extension", g.extId).Str("search", search).Msg("custom source: Fetching anime")
 
-	method, err := g.callClassMethod(ctx, "listAnime", search, page, perPage)
+	res, err := g.callClassMethod(ctx, "listAnime", search, page, perPage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call search method: %w", err)
 	}
 
-	promiseRes, err := g.waitForPromise(method)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for promise: %w", err)
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
 	}
@@ -65,17 +60,12 @@ func (g *GojaCustomSource) ListManga(ctx context.Context, search string, page in
 
 	g.logger.Debug().Str("extension", g.extId).Str("search", search).Msg("custom source: Fetching manga")
 
-	method, err := g.callClassMethod(ctx, "listManga", search, page, perPage)
+	res, err := g.callClassMethod(ctx, "listManga", search, page, perPage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call search method: %w", err)
 	}
 
-	promiseRes, err := g.waitForPromise(method)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for promise: %w", err)
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
 	}
@@ -88,12 +78,12 @@ func (g *GojaCustomSource) GetSettings() (ret hibikecustomsource.Settings) {
 		ret = hibikecustomsource.Settings{}
 	})
 
-	method, err := g.callClassMethod(context.Background(), "getSettings")
+	res, err := g.callClassMethod(context.Background(), "getSettings")
 	if err != nil {
 		return
 	}
 
-	err = g.unmarshalValue(method, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return
 	}
@@ -106,17 +96,12 @@ func (g *GojaCustomSource) GetAnime(ctx context.Context, id []int) (ret []*anili
 
 	g.logger.Debug().Str("extension", g.extId).Ints("ids", id).Msg("custom source: Getting anime")
 
-	method, err := g.callClassMethod(ctx, "getAnime", id)
+	res, err := g.callClassMethod(ctx, "getAnime", id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call search method: %w", err)
 	}
 
-	promiseRes, err := g.waitForPromise(method)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for promise: %w", err)
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
 	}
@@ -129,17 +114,12 @@ func (g *GojaCustomSource) GetAnimeWithRelations(ctx context.Context, id int) (r
 
 	g.logger.Debug().Str("extension", g.extId).Int("id", id).Msg("custom source: Getting anime with relations")
 
-	method, err := g.callClassMethod(ctx, "getAnimeWithRelations", id)
+	res, err := g.callClassMethod(ctx, "getAnimeWithRelations", id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call search method: %w", err)
 	}
 
-	promiseRes, err := g.waitForPromise(method)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for promise: %w", err)
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
 	}
@@ -156,17 +136,12 @@ func (g *GojaCustomSource) GetAnimeMetadata(ctx context.Context, id int) (ret *m
 
 	g.logger.Debug().Str("extension", g.extId).Int("id", id).Msg("custom source: Getting anime metadata")
 
-	method, err := g.callClassMethod(ctx, "getAnimeMetadata", id)
+	res, err := g.callClassMethod(ctx, "getAnimeMetadata", id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call search method: %w", err)
 	}
 
-	promiseRes, err := g.waitForPromise(method)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for promise: %w", err)
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
 	}
@@ -179,17 +154,12 @@ func (g *GojaCustomSource) GetAnimeDetails(ctx context.Context, id int) (ret *an
 
 	g.logger.Debug().Str("extension", g.extId).Int("id", id).Msg("custom source: Getting anime details")
 
-	method, err := g.callClassMethod(ctx, "getAnimeDetails", id)
+	res, err := g.callClassMethod(ctx, "getAnimeDetails", id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call search method: %w", err)
 	}
 
-	promiseRes, err := g.waitForPromise(method)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for promise: %w", err)
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return &anilist.AnimeDetailsById_Media{}, nil
 	}
@@ -202,17 +172,12 @@ func (g *GojaCustomSource) GetManga(ctx context.Context, id []int) (ret []*anili
 
 	g.logger.Debug().Str("extension", g.extId).Ints("ids", id).Msg("custom source: Getting manga")
 
-	method, err := g.callClassMethod(ctx, "getManga", id)
+	res, err := g.callClassMethod(ctx, "getManga", id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call search method: %w", err)
 	}
 
-	promiseRes, err := g.waitForPromise(method)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for promise: %w", err)
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
 	}
@@ -225,17 +190,12 @@ func (g *GojaCustomSource) GetMangaDetails(ctx context.Context, id int) (ret *an
 
 	g.logger.Debug().Str("extension", g.extId).Int("id", id).Msg("custom source: Getting manga details")
 
-	method, err := g.callClassMethod(ctx, "getMangaDetails", id)
+	res, err := g.callClassMethod(ctx, "getMangaDetails", id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call search method: %w", err)
 	}
 
-	promiseRes, err := g.waitForPromise(method)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for promise: %w", err)
-	}
-
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return &anilist.MangaDetailsById_Media{}, nil
 	}

--- a/internal/extension_repo/goja_manga_provider.go
+++ b/internal/extension_repo/goja_manga_provider.go
@@ -33,12 +33,12 @@ func (g *GojaMangaProvider) GetSettings() (ret hibikemanga.Settings) {
 		ret = hibikemanga.Settings{}
 	})
 
-	method, err := g.callClassMethod(context.Background(), "getSettings")
+	res, err := g.callClassMethod(context.Background(), "getSettings")
 	if err != nil {
 		return
 	}
 
-	err = g.unmarshalValue(method, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return
 	}
@@ -49,14 +49,12 @@ func (g *GojaMangaProvider) GetSettings() (ret hibikemanga.Settings) {
 func (g *GojaMangaProvider) Search(opts hibikemanga.SearchOptions) (ret []*hibikemanga.SearchResult, err error) {
 	defer util.HandlePanicInModuleWithError(g.ext.ID+".Search", &err)
 
-	method, err := g.callClassMethod(context.Background(), "search", structToMap(opts))
-
-	promiseRes, err := g.waitForPromise(method)
+	res, err := g.callClassMethod(context.Background(), "search", structToMap(opts))
 	if err != nil {
 		return nil, err
 	}
 
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -87,14 +85,12 @@ func (g *GojaMangaProvider) Search(opts hibikemanga.SearchOptions) (ret []*hibik
 func (g *GojaMangaProvider) FindChapters(id string) (ret []*hibikemanga.ChapterDetails, err error) {
 	defer util.HandlePanicInModuleWithError(g.ext.ID+".FindChapters", &err)
 
-	method, err := g.callClassMethod(context.Background(), "findChapters", id)
-
-	promiseRes, err := g.waitForPromise(method)
+	res, err := g.callClassMethod(context.Background(), "findChapters", id)
 	if err != nil {
 		return nil, err
 	}
 
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -110,14 +106,12 @@ func (g *GojaMangaProvider) FindChapters(id string) (ret []*hibikemanga.ChapterD
 func (g *GojaMangaProvider) FindChapterPages(id string) (ret []*hibikemanga.ChapterPage, err error) {
 	defer util.HandlePanicInModuleWithError(g.ext.ID+".FindChapterPages", &err)
 
-	method, err := g.callClassMethod(context.Background(), "findChapterPages", id)
-
-	promiseRes, err := g.waitForPromise(method)
+	res, err := g.callClassMethod(context.Background(), "findChapterPages", id)
 	if err != nil {
 		return nil, err
 	}
 
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/extension_repo/goja_onlinestream_provider.go
+++ b/internal/extension_repo/goja_onlinestream_provider.go
@@ -31,14 +31,12 @@ func NewGojaOnlinestreamProvider(ext *extension.Extension, language extension.La
 func (g *GojaOnlinestreamProvider) GetEpisodeServers() (ret []string) {
 	ret = make([]string, 0)
 
-	method, err := g.callClassMethod(context.Background(), "getEpisodeServers")
-
-	promiseRes, err := g.waitForPromise(method)
+	res, err := g.callClassMethod(context.Background(), "getEpisodeServers")
 	if err != nil {
 		return
 	}
 
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return
 	}
@@ -49,18 +47,12 @@ func (g *GojaOnlinestreamProvider) GetEpisodeServers() (ret []string) {
 func (g *GojaOnlinestreamProvider) Search(opts hibikeonlinestream.SearchOptions) (ret []*hibikeonlinestream.SearchResult, err error) {
 	defer util.HandlePanicInModuleWithError(g.ext.ID+".Search", &err)
 
-	method, err := g.callClassMethod(context.Background(), "search", structToMap(opts))
+	res, err := g.callClassMethod(context.Background(), "search", structToMap(opts))
 	if err != nil {
 		return nil, fmt.Errorf("failed to call search method: %w", err)
 	}
 
-	promiseRes, err := g.waitForPromise(method)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for promise: %w", err)
-	}
-
-	ret = make([]*hibikeonlinestream.SearchResult, 0)
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal search results: %w", err)
 	}
@@ -71,14 +63,12 @@ func (g *GojaOnlinestreamProvider) Search(opts hibikeonlinestream.SearchOptions)
 func (g *GojaOnlinestreamProvider) FindEpisodes(id string) (ret []*hibikeonlinestream.EpisodeDetails, err error) {
 	defer util.HandlePanicInModuleWithError(g.ext.ID+".FindEpisodes", &err)
 
-	method, err := g.callClassMethod(context.Background(), "findEpisodes", id)
-
-	promiseRes, err := g.waitForPromise(method)
+	res, err := g.callClassMethod(context.Background(), "findEpisodes", id)
 	if err != nil {
 		return nil, err
 	}
 
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -93,16 +83,14 @@ func (g *GojaOnlinestreamProvider) FindEpisodes(id string) (ret []*hibikeonlines
 func (g *GojaOnlinestreamProvider) FindEpisodeServer(episode *hibikeonlinestream.EpisodeDetails, server string) (ret *hibikeonlinestream.EpisodeServer, err error) {
 	defer util.HandlePanicInModuleWithError(g.ext.ID+".FindEpisodeServer", &err)
 
-	method, err := g.callClassMethod(context.Background(), "findEpisodeServer", structToMap(episode), server)
-
-	promiseRes, err := g.waitForPromise(method)
+	res, err := g.callClassMethod(context.Background(), "findEpisodeServer", structToMap(episode), server)
 	if err != nil {
-		return nil, err
+		return
 	}
 
-	err = g.unmarshalValue(promiseRes, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	ret.Provider = g.ext.ID
@@ -115,12 +103,12 @@ func (g *GojaOnlinestreamProvider) GetSettings() (ret hibikeonlinestream.Setting
 		ret = hibikeonlinestream.Settings{}
 	})
 
-	method, err := g.callClassMethod(context.Background(), "getSettings")
+	res, err := g.callClassMethod(context.Background(), "getSettings")
 	if err != nil {
 		return
 	}
 
-	err = g.unmarshalValue(method, &ret)
+	err = g.unmarshalValue(res, &ret)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Exceptions raised in smartSearch function were not being handled by Seanime correctly.

before this PR:
<img width="1731" height="1039" alt="image" src="https://github.com/user-attachments/assets/b0f486f3-ca09-4c7a-8c70-eea214044c36" />

after this PR:
<img width="1731" height="1039" alt="image" src="https://github.com/user-attachments/assets/7f2d0c6d-22d8-422f-adbd-e2c661e059be" />