### PR TITLE
fix(mpv/iina): keep progress tracking alive when a stream's path is briefly unavailable

### DIFF
--- a/internal/mediaplayers/iina/iina.go
+++ b/internal/mediaplayers/iina/iina.go
@@ -333,13 +333,13 @@ func (i *Iina) listenForEvents(ctx context.Context) {
 	events, stopListening := i.conn.NewEventListener()
 	i.Logger.Debug().Msg("iina: Listening for events")
 
-	_, err := i.conn.Get("path")
-	if err != nil {
-		i.Logger.Error().Err(err).Msg("iina: Failed to get path")
-		return
-	}
-
-	_, err = i.conn.Call("observe_property", 42, "time-pos")
+	// Don't probe Get("path") here. For network/torrent streams the file may not
+	// be loaded yet when the IPC connection is established, so mpv returns
+	// "property unavailable". Treating that as fatal tears down the event loop
+	// (and, via terminate(), the player process), which silently breaks progress
+	// tracking. The path, filename, duration and time-pos values are delivered
+	// below via observe_property once the stream finishes loading.
+	_, err := i.conn.Call("observe_property", 42, "time-pos")
 	if err != nil {
 		i.Logger.Error().Err(err).Msg("iina: Failed to observe time-pos")
 		return

--- a/internal/mediaplayers/mpv/mpv.go
+++ b/internal/mediaplayers/mpv/mpv.go
@@ -462,13 +462,13 @@ func (m *Mpv) listenForEvents(ctx context.Context) {
 	events, stopListening := m.conn.NewEventListener()
 	m.Logger.Debug().Msg("mpv: Listening for events")
 
-	_, err := m.conn.Get("path")
-	if err != nil {
-		m.Logger.Error().Err(err).Msg("mpv: Failed to get path")
-		return
-	}
-
-	_, err = m.conn.Call("observe_property", 42, "time-pos")
+	// Don't probe Get("path") here. For network/torrent streams the file may not
+	// be loaded yet when the IPC connection is established, so mpv returns
+	// "property unavailable". Treating that as fatal tears down the event loop
+	// (and, via terminate(), the player process), which silently breaks progress
+	// tracking. The path, filename, duration and time-pos values are delivered
+	// below via observe_property once the stream finishes loading.
+	_, err := m.conn.Call("observe_property", 42, "time-pos")
 	if err != nil {
 		m.Logger.Error().Err(err).Msg("mpv: Failed to observe time-pos")
 		return


### PR DESCRIPTION
## Problem

When playing a **torrent/debrid stream** with mpv (and IINA), Seanime intermittently stops tracking playback progress — the video keeps playing fine in the player, but the app never advances progress and eventually logs `media player > Ending goroutine, waited too long`. Downloaded local files always track correctly.

Representative log:

```
mpv > Player started
mpv > Connection established
playback manager > Started tracking torrent stream
mpv > Listening for events
ERR mpv > Failed to get path error="mpv error: property unavailable"
mpv > Closing socket connection / Terminating / Resetting playback status
WRN mpv > Player has exited error="exit status 1"
media player > Waiting for stream, 0..60 seconds
media player > Ending goroutine, waited too long
```

## Root cause

`listenForEvents` probes `conn.Get("path")` immediately after the IPC connection is established and treats **any** error as fatal:

```go
_, err := m.conn.Get("path")
if err != nil {
    m.Logger.Error().Err(err).Msg("mpv: Failed to get path")
    return
}
```

For a network stream, mpv usually hasn't finished opening/demuxing the file at that instant, so it legitimately replies `property unavailable`. The early `return` runs the deferred cleanup, which closes the IPC connection and calls `terminate()` (which cancels the player's command context and resets the playback status via `resetPlaybackStatus()`).

After that, the stream-tracking goroutine's `GetPlaybackStatus()` can never succeed (it requires `IsRunning && Filename != "" && Duration != 0`, all populated only by the now-dead event loop), so it logs `Waiting for stream, N seconds` and gives up after ~60s.

## Why it's intermittent

It's a race between mpv finishing the network open/demux and the fixed ~3s startup delay before the probe runs. Fast first piece → `path` ready → tracking works; cold torrent / slow start → `path` still unavailable → tracking dropped. Local files load synchronously and always win the race, which is why they always track.

## Fix

The probe's return value was discarded anyway — `path`, `filename`, `duration` and `time-pos` are all delivered just below via `observe_property` once the stream finishes loading. Removing the fatal probe lets the event loop stay alive, so the observed properties populate the playback status and tracking works for streams too.

Liveness is still covered by `WaitUntilClosed`, the `ctx.Done()` handler, and the tracking goroutine's own timeout; the remaining `observe_property` calls still bail on error (those only fail on an already-dead IPC channel).

The IINA event loop contained the identical probe and is fixed the same way.

## Testing

- `go build ./internal/mediaplayers/mpv/ ./internal/mediaplayers/iina/` — ok
- `go vet ./internal/mediaplayers/mpv/ ./internal/mediaplayers/iina/` — ok
- Verified with a deterministic local reproduction: launch mpv idle (so `path` is `property unavailable` at connect time, exactly like a not-yet-loaded stream), run `listenForEvents`, then load a file. On the original code this reproduces the exact `Failed to get path error="property unavailable"` and tears the connection down; with this change the event loop survives and `GetPlaybackStatus()` reports the filename and duration.
