### PR TITLE
fix(torrentstream): select batch file by episode instead of incrementing index

### DIFF
--- a/codegen/generated/public_structs.json
+++ b/codegen/generated/public_structs.json
@@ -41677,6 +41677,15 @@
         "required": true,
         "public": true,
         "comments": []
+      },
+      {
+        "name": "EpisodeNumber",
+        "jsonName": "episodeNumber",
+        "goType": "int",
+        "typescriptType": "number",
+        "required": true,
+        "public": true,
+        "comments": []
       }
     ],
     "comments": []

--- a/internal/extension/hibike/torrent/types.go
+++ b/internal/extension/hibike/torrent/types.go
@@ -172,6 +172,9 @@ type (
 		Index int    `json:"index"`
 		Path  string `json:"path"`
 		Name  string `json:"name"`
+		// EpisodeNumber is the episode parsed from the file name, or 0 if unknown.
+		// Used to map a batch file to an episode regardless of file order.
+		EpisodeNumber int `json:"episodeNumber"`
 	}
 
 	BatchEpisodeFiles struct {

--- a/seanime-web/src/api/generated/types.ts
+++ b/seanime-web/src/api/generated/types.ts
@@ -3110,6 +3110,7 @@ export type HibikeTorrent_AnimeTorrentFile = {
     index: number
     path: string
     name: string
+    episodeNumber: number
 }
 
 /**

--- a/seanime-web/src/app/(main)/_features/autoplay/autoplay.ts
+++ b/seanime-web/src/app/(main)/_features/autoplay/autoplay.ts
@@ -56,13 +56,42 @@ export function useAutoPlaySelectedTorrent() {
     }
 }
 
-export function getNextBatchFileSelection(
+/**
+ * Resolves which file of a batch torrent corresponds to the target episode.
+ *
+ * Primary strategy: match the file whose parsed episode number equals the target
+ * episode. This is robust even when the torrent's files are not ordered by episode
+ * (common with batch releases, e.g. file index 0 holding episode 12).
+ *
+ * Fallback (when the parsed episode number is unknown, e.g. unparseable names or
+ * absolute-numbered batches): derive the file index from the episode offset
+ * relative to the currently-mapped episode. This works in both directions
+ * (previous/next) and for arbitrary jumps, unlike a naive "current + 1" which only
+ * holds when moving strictly forward and silently drifts once the user goes
+ * backward or skips.
+ */
+export function getBatchFileSelectionForEpisode(
     batchFiles: HibikeTorrent_BatchEpisodeFiles | undefined,
     episodeNumber: number,
     aniDBEpisode: string,
 ) {
-    const file = batchFiles?.files?.find(n => n.index === batchFiles.current + 1)
-    if (!batchFiles || !file) {
+    if (!batchFiles) {
+        return { fileIndex: undefined, batchEpisodeFiles: undefined }
+    }
+
+    // Prefer matching the file by its parsed episode number.
+    let file = batchFiles.files?.find(n => n.episodeNumber > 0 && n.episodeNumber === episodeNumber)
+
+    // Fallback: reuse the currently-mapped file when re-selecting the same episode,
+    // otherwise derive the index from the episode offset relative to it.
+    if (!file) {
+        const targetIndex = batchFiles.currentAniDBEpisode === aniDBEpisode
+            ? batchFiles.current
+            : batchFiles.current + (episodeNumber - batchFiles.currentEpisodeNumber)
+        file = batchFiles.files?.find(n => n.index === targetIndex)
+    }
+
+    if (!file) {
         return { fileIndex: undefined, batchEpisodeFiles: undefined }
     }
 
@@ -95,7 +124,7 @@ export function useTorrentstreamAutoplay() {
             torrentInfo = null
         }
 
-        const { fileIndex, batchEpisodeFiles } = getNextBatchFileSelection(torrentInfo?.batchFiles, episodeNumber, aniDBEpisode)
+        const { fileIndex, batchEpisodeFiles } = getBatchFileSelectionForEpisode(torrentInfo?.batchFiles, episodeNumber, aniDBEpisode)
 
         logger("TORRENT STREAM AUTOPLAY").info("Auto playing next episode", { episodeNumber, fileIndex, preload, torrent: torrentInfo?.torrent })
 
@@ -166,13 +195,7 @@ export function useDebridstreamAutoplay() {
 
         if (autoPlayTorrent?.torrent?.isBatch) {
 
-            let fileIndex: number | undefined = undefined
-            if (autoPlayTorrent?.batchFiles) {
-                const file = autoPlayTorrent.batchFiles.files?.find(n => n.index === autoPlayTorrent.batchFiles!.current + 1)
-                if (file) {
-                    fileIndex = file.index
-                }
-            }
+            const { fileIndex, batchEpisodeFiles } = getBatchFileSelectionForEpisode(autoPlayTorrent?.batchFiles, episodeNumber, aniDBEpisode)
 
             // If the user provided a torrent, use it
             handleStreamSelection({
@@ -181,12 +204,7 @@ export function useDebridstreamAutoplay() {
                 aniDBEpisode: aniDBEpisode,
                 torrent: autoPlayTorrent.torrent,
                 chosenFileId: fileIndex !== undefined ? String(fileIndex) : "",
-                batchEpisodeFiles: (autoPlayTorrent?.batchFiles && fileIndex !== undefined) ? {
-                    ...autoPlayTorrent.batchFiles,
-                    current: fileIndex,
-                    currentEpisodeNumber: episodeNumber,
-                    currentAniDBEpisode: aniDBEpisode,
-                } : undefined,
+                batchEpisodeFiles: batchEpisodeFiles,
             })
         } else {
             // Otherwise, use the auto-select function

--- a/seanime-web/src/app/(main)/_features/playlists/_containers/global-playlist-manager.tsx
+++ b/seanime-web/src/app/(main)/_features/playlists/_containers/global-playlist-manager.tsx
@@ -1,7 +1,7 @@
 import { Anime_Entry, Anime_Playlist, Anime_PlaylistEpisode, HibikeTorrent_AnimeTorrent } from "@/api/generated/types"
 import { useGetAnimeEntry } from "@/api/hooks/anime_entries.hooks"
 import { useCurrentDevicePlaybackSettings } from "@/app/(main)/_atoms/playback.atoms"
-import { getNextBatchFileSelection, useAutoPlaySelectedTorrent } from "@/app/(main)/_features/autoplay/autoplay"
+import { getBatchFileSelectionForEpisode, useAutoPlaySelectedTorrent } from "@/app/(main)/_features/autoplay/autoplay"
 import { nativePlayer_stateAtom } from "@/app/(main)/_features/native-player/native-player.atoms"
 import { PlaylistManagerPopup } from "@/app/(main)/_features/playlists/_components/global-playlist-popup"
 import { playlist_getEpisodeKey, playlist_isSameEpisode } from "@/app/(main)/_features/playlists/_components/playlist-editor"
@@ -273,7 +273,7 @@ export function GlobalPlaylistManager() {
                             } else {
                                 if (autoPlayTorrent?.torrent?.isBatch && torrentStream_autoSelectFile && sameTorrent(autoPlayTorrent, episode)) {
                                     log.info("Previous selection matches, auto-selecting file for torrent stream")
-                                    const batchSelection = getNextBatchFileSelection(
+                                    const batchSelection = getBatchFileSelectionForEpisode(
                                         autoPlayTorrent.batchFiles,
                                         episode.episode?.episodeNumber!,
                                         episode.episode?.aniDBEpisode!,

--- a/seanime-web/src/app/(main)/_features/video-core/video-core-playlist.tsx
+++ b/seanime-web/src/app/(main)/_features/video-core/video-core-playlist.tsx
@@ -2,7 +2,7 @@ import { Anime_Entry, Anime_Episode } from "@/api/generated/types"
 import { useGetAnimeEpisodeCollection } from "@/api/hooks/anime.hooks"
 import { useGetAnimeEntry } from "@/api/hooks/anime_entries.hooks"
 import { EpisodeGridItem } from "@/app/(main)/_features/anime/_components/episode-grid-item"
-import { getNextBatchFileSelection, useAutoPlaySelectedTorrent, useTorrentstreamAutoplay } from "@/app/(main)/_features/autoplay/autoplay"
+import { getBatchFileSelectionForEpisode, useAutoPlaySelectedTorrent, useTorrentstreamAutoplay } from "@/app/(main)/_features/autoplay/autoplay"
 import { useNakamaWatchParty } from "@/app/(main)/_features/nakama/nakama-manager"
 import { usePlaylistManager } from "@/app/(main)/_features/playlists/_containers/global-playlist-manager"
 import { VideoCoreNextButton, VideoCorePreviousButton } from "@/app/(main)/_features/video-core/video-core-control-bar"
@@ -198,15 +198,8 @@ export function useVideoCorePlaylist() {
         // If a torrent was selected for auto play (i.e. user manually select torrent with auto select file)
         if (autoPlayTorrent?.torrent?.isBatch) {
             log.info("Previous torrent selected for auto play", autoPlayTorrent)
-            let fileIndex: number | undefined = undefined
-            if (autoPlayTorrent?.batchFiles) {
-                const file = autoPlayTorrent.batchFiles.files?.find(n => n.index === autoPlayTorrent.batchFiles!.current + 1)
-                if (file) {
-                    fileIndex = file.index
-                }
-            }
+            const batchSelection = getBatchFileSelectionForEpisode(autoPlayTorrent.batchFiles, episode.episodeNumber, episode.aniDBEpisode)
             if (playbackType === "torrent") {
-                const batchSelection = getNextBatchFileSelection(autoPlayTorrent.batchFiles, episode.episodeNumber, episode.aniDBEpisode)
                 handleTorrentstreamSelection({
                     mediaId: playlistState.animeEntry.mediaId,
                     episodeNumber: episode.episodeNumber,
@@ -225,13 +218,8 @@ export function useVideoCorePlaylist() {
                     episodeNumber: episode.episodeNumber,
                     aniDBEpisode: episode.aniDBEpisode,
                     torrent: autoPlayTorrent.torrent,
-                    chosenFileId: fileIndex !== undefined ? String(fileIndex) : "",
-                    batchEpisodeFiles: (autoPlayTorrent?.batchFiles && fileIndex !== undefined) ? {
-                        ...autoPlayTorrent.batchFiles,
-                        current: fileIndex,
-                        currentEpisodeNumber: episode.episodeNumber,
-                        currentAniDBEpisode: episode.aniDBEpisode,
-                    } : undefined,
+                    chosenFileId: batchSelection.fileIndex !== undefined ? String(batchSelection.fileIndex) : "",
+                    batchEpisodeFiles: batchSelection.batchEpisodeFiles,
                 })
             }
         } else {

--- a/seanime-web/src/app/(main)/entry/_containers/debrid-stream/debrid-stream-file-selection-modal.tsx
+++ b/seanime-web/src/app/(main)/entry/_containers/debrid-stream/debrid-stream-file-selection-modal.tsx
@@ -60,7 +60,7 @@ export function DebridStreamFileSelectionModal(props: DebridStreamFileSelectionM
         if (selectedDebridService !== DEBRID_SERVICE.TORBOX) {
             batchFiles = {
                 current: parseInt(selectedFileId),
-                files: previews?.map(n => { return { index: n.index, name: n.displayPath, path: n.path } }) || [],
+                files: previews?.map(n => { return { index: n.index, name: n.displayPath, path: n.path, episodeNumber: n.episodeNumber } }) || [],
                 currentEpisodeNumber: torrentSearchStreamEpisode.episodeNumber,
                 currentAniDBEpisode: torrentSearchStreamEpisode.aniDBEpisode,
             }

--- a/seanime-web/src/app/(main)/entry/_containers/debrid-stream/debrid-stream-page.tsx
+++ b/seanime-web/src/app/(main)/entry/_containers/debrid-stream/debrid-stream-page.tsx
@@ -1,7 +1,7 @@
 import { Anime_Entry, Anime_Episode } from "@/api/generated/types"
 import { useGetAnimeEpisodeCollection } from "@/api/hooks/anime.hooks"
 import { useDeleteTorrentstreamBatchHistory, useGetTorrentstreamBatchHistory } from "@/api/hooks/torrentstream.hooks"
-import { useDebridstreamAutoplay } from "@/app/(main)/_features/autoplay/autoplay"
+import { getBatchFileSelectionForEpisode, useDebridstreamAutoplay } from "@/app/(main)/_features/autoplay/autoplay"
 import { useSelectedDebridService, useServerStatus } from "@/app/(main)/_hooks/use-server-status"
 import { useHandleStartDebridStream } from "@/app/(main)/entry/_containers/debrid-stream/_lib/handle-debrid-stream"
 import { ENTRY_VIEW_TRANSITION } from "@/app/(main)/entry/_containers/entry-view-transition"
@@ -194,42 +194,24 @@ export function DebridStreamPage(props: DebridStreamPageProps) {
                     })
                     started = true
                 } else {
-                    // Only auto select the file index if the user is trying to watch the next episode
+                    // Resolve the batch file for the requested episode, relative to the
+                    // last selected file (works for previous/next and arbitrary jumps).
                     if (batchHistory?.batchEpisodeFiles && selectedDebridService !== DEBRID_SERVICE.TORBOX) {
-                        let fileIndex: number | undefined = undefined
-
-                        console.log("handleEpisodeClick (batchHistory)",
-                            batchHistory?.batchEpisodeFiles,
+                        const batchSelection = getBatchFileSelectionForEpisode(
+                            batchHistory.batchEpisodeFiles,
+                            episode.episodeNumber,
                             episode.aniDBEpisode,
-                            episode.episodeNumber)
+                        )
 
-                        if (batchHistory?.batchEpisodeFiles.currentAniDBEpisode === episode.aniDBEpisode) {
-                            fileIndex = batchHistory.batchEpisodeFiles.current
-                        } else {
-                            // guess index based on the last selected file
-                            const offset = episode.episodeNumber - batchHistory.batchEpisodeFiles.currentEpisodeNumber
-                            const file = batchHistory.batchEpisodeFiles.files?.find(f => f.index === (batchHistory.batchEpisodeFiles?.current || 0) + offset)
-                            if (file) {
-                                fileIndex = file.index
-                                console.log("handleEpisodeClick (batchHistory) found file", file)
-                            }
-                        }
-
-                        if (fileIndex !== undefined) {
+                        if (batchSelection.fileIndex !== undefined) {
                             forcePlaybackMethodFn(forcePlaybackMethod, () => {
                                 handleStreamSelection({
                                     mediaId: entry.mediaId,
                                     episodeNumber: episode.episodeNumber,
                                     aniDBEpisode: episode.aniDBEpisode!,
                                     torrent: batchHistory.torrent!,
-                                    chosenFileId: String(fileIndex),
-                                    batchEpisodeFiles: (batchHistory.batchEpisodeFiles) ? {
-                                        ...batchHistory.batchEpisodeFiles!,
-                                        files: batchHistory.batchEpisodeFiles!.files!,
-                                        current: fileIndex!,
-                                        currentAniDBEpisode: episode.aniDBEpisode!,
-                                        currentEpisodeNumber: episode.episodeNumber,
-                                    } : undefined,
+                                    chosenFileId: String(batchSelection.fileIndex),
+                                    batchEpisodeFiles: batchSelection.batchEpisodeFiles,
                                 })
                             })
                             started = true

--- a/seanime-web/src/app/(main)/entry/_containers/torrent-stream/_lib/handle-torrent-stream.ts
+++ b/seanime-web/src/app/(main)/entry/_containers/torrent-stream/_lib/handle-torrent-stream.ts
@@ -6,7 +6,7 @@ import {
     useCurrentDevicePlaybackSettings,
     useExternalPlayerLink,
 } from "@/app/(main)/_atoms/playback.atoms"
-import { getNextBatchFileSelection, useAutoPlaySelectedTorrent, useTorrentstreamAutoplay } from "@/app/(main)/_features/autoplay/autoplay"
+import { getBatchFileSelectionForEpisode, useAutoPlaySelectedTorrent, useTorrentstreamAutoplay } from "@/app/(main)/_features/autoplay/autoplay"
 import { usePlaylistManager } from "@/app/(main)/_features/playlists/_containers/global-playlist-manager"
 import { useWebsocketMessageListener } from "@/app/(main)/_hooks/handle-websockets"
 import { useServerStatus } from "@/app/(main)/_hooks/use-server-status"
@@ -168,7 +168,7 @@ export function useTorrentStreamListener() {
                         ) {
                             logger("TORRENT STREAM LISTENER")
                                 .info("Previous selection matches, preparing next stream by auto-selecting file for torrent stream")
-                            const batchSelection = getNextBatchFileSelection(autoPlayTorrent.batchFiles,
+                            const batchSelection = getBatchFileSelectionForEpisode(autoPlayTorrent.batchFiles,
                                 episode.episodeNumber!,
                                 episode.aniDBEpisode!)
                             handleStreamSelection({

--- a/seanime-web/src/app/(main)/entry/_containers/torrent-stream/torrent-stream-file-selection-modal.tsx
+++ b/seanime-web/src/app/(main)/entry/_containers/torrent-stream/torrent-stream-file-selection-modal.tsx
@@ -46,7 +46,7 @@ export function TorrentstreamFileSelectionModal({ entry }: { entry: Anime_Entry 
         // autoplay will increment selectedFileIdx by 1 to play the next file
         const batchFiles: HibikeTorrent_BatchEpisodeFiles = {
             current: selectedFileIdx,
-            files: filePreviews?.map(n => { return { index: n.index, name: n.displayPath, path: n.path } }) || [],
+            files: filePreviews?.map(n => { return { index: n.index, name: n.displayPath, path: n.path, episodeNumber: n.episodeNumber } }) || [],
             currentEpisodeNumber: torrentSearchStreamEpisode.episodeNumber,
             currentAniDBEpisode: torrentSearchStreamEpisode.aniDBEpisode,
         }

--- a/seanime-web/src/app/(main)/entry/_containers/torrent-stream/torrent-stream-page.tsx
+++ b/seanime-web/src/app/(main)/entry/_containers/torrent-stream/torrent-stream-page.tsx
@@ -1,7 +1,7 @@
 import { Anime_Entry, Anime_Episode } from "@/api/generated/types"
 import { useGetAnimeEpisodeCollection } from "@/api/hooks/anime.hooks"
 import { useDeleteTorrentstreamBatchHistory, useGetTorrentstreamBatchHistory } from "@/api/hooks/torrentstream.hooks"
-import { useAutoPlaySelectedTorrent, useTorrentstreamAutoplay } from "@/app/(main)/_features/autoplay/autoplay"
+import { getBatchFileSelectionForEpisode, useAutoPlaySelectedTorrent, useTorrentstreamAutoplay } from "@/app/(main)/_features/autoplay/autoplay"
 
 import { useSeaCommandInject } from "@/app/(main)/_features/sea-command/use-inject"
 import { useServerStatus } from "@/app/(main)/_hooks/use-server-status"
@@ -196,42 +196,29 @@ export function TorrentStreamPage(props: TorrentStreamPageProps) {
                             })
                             started = true
                         } else {
-                            // Only auto select the file index if the user is trying to watch the next episode
+                            // Resolve the batch file for the requested episode, relative to the
+                            // last selected file (works for previous/next and arbitrary jumps).
                             if (batchHistory?.batchEpisodeFiles) {
-                                let fileIndex: number | undefined = undefined
-
-                                console.log("handleEpisodeClick (batchHistory)",
-                                    batchHistory?.batchEpisodeFiles,
+                                const batchSelection = getBatchFileSelectionForEpisode(
+                                    batchHistory.batchEpisodeFiles,
+                                    episode.episodeNumber,
                                     episode.aniDBEpisode,
-                                    episode.episodeNumber)
+                                )
 
-                                if (batchHistory?.batchEpisodeFiles.currentAniDBEpisode === episode.aniDBEpisode) {
-                                    fileIndex = batchHistory.batchEpisodeFiles.current
-                                } else {
-                                    // guess index based on the last selected file
-                                    const offset = episode.episodeNumber - batchHistory.batchEpisodeFiles.currentEpisodeNumber
-                                    const file = batchHistory.batchEpisodeFiles.files?.find(f => f.index === (batchHistory.batchEpisodeFiles?.current || 0) + offset)
-                                    if (file) {
-                                        fileIndex = file.index
-                                        console.log("handleEpisodeClick (batchHistory) found file", file)
+                                if (batchSelection.fileIndex !== undefined) {
+                                    // Anchor autoplay to the episode actually being played so
+                                    // subsequent in-player navigation computes offsets correctly.
+                                    if (batchSelection.batchEpisodeFiles) {
+                                        setAutoPlayTorrent(batchHistory.torrent!, entry, batchSelection.batchEpisodeFiles)
                                     }
-                                }
-
-                                if (fileIndex !== undefined) {
                                     forcePlaybackMethodFn(forcePlaybackMethod, () => {
                                         handleStreamSelection({
                                             mediaId: entry.mediaId,
                                             episodeNumber: episode.episodeNumber,
                                             aniDBEpisode: episode.aniDBEpisode!,
                                             torrent: batchHistory.torrent!,
-                                            chosenFileIndex: fileIndex,
-                                            batchEpisodeFiles: (batchHistory.batchEpisodeFiles) ? {
-                                                ...batchHistory.batchEpisodeFiles!,
-                                                files: batchHistory.batchEpisodeFiles!.files!,
-                                                current: fileIndex!,
-                                                currentAniDBEpisode: episode.aniDBEpisode!,
-                                                currentEpisodeNumber: episode.episodeNumber,
-                                            } : undefined,
+                                            chosenFileIndex: batchSelection.fileIndex,
+                                            batchEpisodeFiles: batchSelection.batchEpisodeFiles,
                                         })
                                     })
                                     started = true


### PR DESCRIPTION
## Summary

Fixes #835 — when navigating forward/backward in the integrated player while streaming a **batch** torrent, the wrong episode file was selected even though the player showed the correct episode number.

## Root cause

Batch navigation picked the file by incrementing the *file index* (`current + 1`). That only works when:
1. you move strictly **forward**, and
2. the torrent's files happen to be ordered by episode.

Neither holds in general:
- Going **backward** (or jumping) still did `current + 1`, so it played the *next* file and then drifted further out of sync.
- Many batch releases store files in a **non-episode order**. In the reporter's torrents (`[Judas]` / `[EMBER]` releases) file index `0` is episode **12**, index `6` is episode **1**, etc. — so even forward navigation landed on arbitrary episodes.

The same buggy `current + 1` logic was duplicated across the player prev/next buttons, autoplay, and preload, while the episode-list path used a slightly better (but still order-dependent) offset.

## Fix

The backend already parses a per-file episode number for the file-preview UI (`FilePreview.episodeNumber`), but the frontend discarded it when building the batch file list. This PR:

- Adds `episodeNumber` to the batch file model (`AnimeTorrentFile`) and populates it from the previews in both the torrent and debrid file-selection modals.
- Rewrites selection to **match the file by its parsed episode number**, falling back to a *direction-aware* offset (relative to the currently-mapped episode) only when the episode number is unknown — e.g. unparseable names or absolute-numbered batches.
- Unifies every navigation entry point (player previous/next, episode list, autoplay, preload, global playlist) for **both torrent and debrid** streaming onto a single `getBatchFileSelectionForEpisode` helper, removing the three `current + 1` copies.

This is robust regardless of the torrent's internal file order. Batches with unknown/absolute episode numbers degrade to the offset behaviour (and `auto-select-file`, which routes through the backend analyzer, remains the most robust option for those).

## Verification

- `go build` / `go vet` / `go test ./internal/torrents/analyzer/` pass.
- `npm run typecheck` passes.
- Simulated the fixed selection over the **exact scrambled file lists from the issue's attached logs**: every episode (including the out-of-order boundary episodes 1 and 12) now resolves to the correct file, whereas the old logic reproduced the reporter's exact wrong outputs.

## Manual test plan

1. Batch torrent (files **not** ordered by episode), manual file selection. Play ep 5, then press **previous** → ep 4 plays the correct file (previously played the wrong episode).
2. From ep 5, jump to ep 1 and ep 12 via the episode list → correct files.
3. Forward autoplay through several episodes → correct files.
4. Repeat the above on a debrid batch.

> Note: `AnimeTorrentFile` gains an optional `episodeNumber` field (defaults to `0`/unknown); existing extensions are unaffected. Generated types and `public_structs.json` were regenerated via `go generate ./codegen/main.go`.