### PR TITLE
Add additional playback speed controls

### DIFF
--- a/seanime-web/package.json
+++ b/seanime-web/package.json
@@ -44,6 +44,7 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slider": "^1.4.3",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/seanime-web/src/app/(main)/_features/video-core/video-core-settings-menu.tsx
+++ b/seanime-web/src/app/(main)/_features/video-core/video-core-settings-menu.tsx
@@ -542,7 +542,7 @@ export function VideoCoreSettingsMenu() {
                                 +
                             </Button>
                         </div>
-                        <div className="flex gap-1.5 items-center mt-3 mb-1">
+                        <div className="flex gap-1.5 items-center mt-3">
                             <Button 
                                 className="px-1 !text-xs flex-1" 
                                 intent="gray-subtle" 

--- a/seanime-web/src/app/(main)/_features/video-core/video-core-settings-menu.tsx
+++ b/seanime-web/src/app/(main)/_features/video-core/video-core-settings-menu.tsx
@@ -39,6 +39,7 @@ import {
 import { vc_dispatchAction } from "@/app/(main)/_features/video-core/video-core.utils"
 import { useServerStatus } from "@/app/(main)/_hooks/use-server-status"
 import { Button } from "@/components/ui/button"
+import { Slider } from "@/components/ui/slider"
 import { Switch } from "@/components/ui/switch"
 import { upath } from "@/lib/helpers/upath"
 import { useAtomValue } from "jotai"
@@ -512,20 +513,77 @@ export function VideoCoreSettingsMenu() {
                         />
                     </VideoCoreMenuOption>
                     <VideoCoreMenuOption title="Playback Speed" icon={MdSpeed}>
-                        <VideoCoreSettingSelect
-                            options={[
-                                { label: "0.5x", value: 0.5 },
-                                { label: "0.9x", value: 0.9 },
-                                { label: "1x", value: 1 },
-                                { label: "1.1x", value: 1.1 },
-                                { label: "1.5x", value: 1.5 },
-                                { label: "2x", value: 2 },
-                            ]}
-                            onValueChange={(v: number) => {
-                                setPlaybackRate(v)
-                            }}
-                            value={playbackRate}
-                        />
+                        <p className="text-center font-semibold mt-2 select-none">
+                            {(playbackRate).toFixed(2)}x
+                        </p>
+                        <div className="flex gap-1.5 items-center mt-1">
+                            <Button 
+                                className="px-1 pl-4 pr-4 !text-xs flex-1" 
+                                intent="gray-subtle" 
+                                size="sm" 
+                                onClick={() => setPlaybackRate(playbackRate > 0.25 ? playbackRate - 0.05 : playbackRate)}
+                            >
+                                -
+                            </Button>
+                            <Slider
+                                value={[playbackRate]} 
+                                defaultValue={[1]} 
+                                min={0.25} 
+                                max={2} 
+                                step={0.05} 
+                                onValueChange={(v) => setPlaybackRate(v[0])}>
+                            </Slider>
+                            <Button 
+                                className="px-1 pl-4 pr-4 !text-xs flex-1" 
+                                intent="gray-subtle" 
+                                size="sm" 
+                                onClick={() => setPlaybackRate(playbackRate < 2 ? playbackRate + 0.05 : playbackRate)}
+                            >
+                                +
+                            </Button>
+                        </div>
+                        <div className="flex gap-1.5 items-center mt-3 mb-1">
+                            <Button 
+                                className="px-1 !text-xs flex-1" 
+                                intent="gray-subtle" 
+                                size="sm" 
+                                onClick={() => setPlaybackRate(0.5)}
+                            >
+                                0.5
+                            </Button>
+                            <Button 
+                                className="px-1 !text-xs flex-1" 
+                                intent="gray-subtle" 
+                                size="sm" 
+                                onClick={() => setPlaybackRate(1)}
+                            >
+                                1.0
+                            </Button>
+                            <Button 
+                                className="px-1 !text-xs flex-1" 
+                                intent="gray-subtle" 
+                                size="sm" 
+                                onClick={() => setPlaybackRate(1.2)}
+                            >
+                                1.2
+                            </Button>
+                            <Button 
+                                className="px-1 !text-xs flex-1" 
+                                intent="gray-subtle" 
+                                size="sm" 
+                                onClick={() => setPlaybackRate(1.5)}
+                            >
+                                1.5
+                            </Button>
+                            <Button 
+                                className="px-1 !text-xs flex-1" 
+                                intent="gray-subtle" 
+                                size="sm" 
+                                onClick={() => setPlaybackRate(2)}
+                            >
+                                2.0
+                            </Button>
+                        </div>
                     </VideoCoreMenuOption>
                     <VideoCoreMenuOption title="Auto Play" icon={IoCaretForwardCircleOutline}>
                         <VideoCoreSettingSelect

--- a/seanime-web/src/components/ui/slider/index.tsx
+++ b/seanime-web/src/components/ui/slider/index.tsx
@@ -1,0 +1,1 @@
+export * from "./slider"

--- a/seanime-web/src/components/ui/slider/slider.tsx
+++ b/seanime-web/src/components/ui/slider/slider.tsx
@@ -1,0 +1,68 @@
+import { cn } from "../core/styling"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+import { cva } from "class-variance-authority"
+import * as React from "react"
+
+/* -------------------------------------------------------------------------------------------------
+ * Anatomy
+ * -----------------------------------------------------------------------------------------------*/
+
+export const SliderAnatomy = {
+    root: cva([
+        "UI-Slider__root",
+        "relative shrink grow flex items-center",
+    ], {
+        variants: {
+            orientation: {
+                horizontal: "w-full h-[20px]",
+                vertical: "h-full w-[20px]",
+            },
+        },
+    }),
+    track: cva([
+        "UI-Slider__track",
+        // hide overflow to make range rounded
+        "relative grow bg-[--border] h-[3px] rounded overflow-hidden",
+    ]),
+    thumb: cva([
+        "UI-Slider__thumb",
+        "block h-[15px] w-[15px] rounded-[15px] bg-white",
+    ]),
+    range: cva([
+        "UI-Slider__range",
+        "absolute h-full bg-white",
+    ]),
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * Slider
+ * -----------------------------------------------------------------------------------------------*/
+
+export type SliderProps = React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+
+export const Slider = React.forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
+    const {
+        className,
+        orientation = "horizontal",
+        ...rest
+    } = props
+
+    return (
+        <SliderPrimitive.Root
+            ref={ref}
+            orientation={orientation}
+            className={cn(
+                SliderAnatomy.root({ orientation }),
+                className,
+            )}
+            {...rest}
+        >
+            <SliderPrimitive.Track className={SliderAnatomy.track()}>
+			    <SliderPrimitive.Range className={SliderAnatomy.range()} />
+            </SliderPrimitive.Track>
+            <SliderPrimitive.Thumb className={SliderAnatomy.thumb()} />
+        </SliderPrimitive.Root>
+    )
+})
+
+Slider.displayName = "Slider"


### PR DESCRIPTION
Add a reusable Slider UI component (src/components/ui/slider/{index,slider}.tsx) built on @radix-ui/react-slider and integrate it into the video settings. 
Update package.json to include @radix-ui/react-slider. 
Replace the previous playback-speed select in VideoCoreSettingsMenu with a numeric display, a Radix-based slider (min 0.25, max 2, step 0.05), +/- buttons and several preset buttons for quick speed selection to provide finer playback rate control.