### PR TITLE
fix(mediastream): correct RFC 6381 codec strings so browsers can direct play more formats

### DIFF
--- a/internal/mediastream/videofile/info.go
+++ b/internal/mediastream/videofile/info.go
@@ -141,7 +141,9 @@ func (e *MediaInfoExtractor) GetInfo(ffprobePath, path string) (mi *MediaInfo, e
 
 	e.logger.Debug().Str("path", path).Str("hash", hash).Msg("mediastream: Getting media information [MediaInfoExtractor]")
 
-	bucketName := fmt.Sprintf("mediastream_mediainfo_%s", hash)
+	// v2: invalidates entries cached before the RFC 6381 codec string fixes
+	// (hevc/av1 level formatting, opus/ac3/eac3 strings, vp8/vp9/mp3/vorbis mappings)
+	bucketName := fmt.Sprintf("mediastream_mediainfo_v2_%s", hash)
 	bucket := filecache.NewBucket(bucketName, 24*7*52*time.Hour)
 	e.logger.Trace().Str("bucketName", bucketName).Msg("mediastream: Using cache bucket [MediaInfoExtractor]")
 
@@ -320,6 +322,22 @@ func FfprobeGetInfo(ffprobePath, path, hash string) (*MediaInfo, error) {
 		codecs = append(codecs, *mi.Audios[0].MimeCodec)
 	}
 	container := mime.TypeByExtension(fmt.Sprintf(".%s", mi.Extension))
+	if container == "" {
+		// mime.TypeByExtension depends on the OS mime database (/etc/mime.types on Linux),
+		// which is missing from minimal docker images. Fall back to known video containers.
+		switch strings.ToLower(mi.Extension) {
+		case "mkv":
+			container = "video/x-matroska"
+		case "mp4", "m4v":
+			container = "video/mp4"
+		case "webm":
+			container = "video/webm"
+		case "mov":
+			container = "video/quicktime"
+		case "avi":
+			container = "video/x-msvideo"
+		}
+	}
 	if container != "" {
 		if len(codecs) > 0 {
 			codecsStr := strings.Join(codecs, ", ")
@@ -384,18 +402,25 @@ func streamToMimeCodec(stream *ffprobe.Stream) *string {
 		return &ret
 
 	case "h265", "hevc":
-		// The h265 syntax is a bit of a mystery at the time this comment was written.
-		// This is what I've found through various sources:
-		// FORMAT: [codecTag].[profile].[constraint?].L[level * 30].[UNKNOWN]
+		// FORMAT: [codecTag].[profile].[compatibility].L[level].[constraints]
+		// e.g. "hvc1.1.6.L120.B0" (Main, level 4.0), "hvc1.2.4.L153.B0" (Main 10, level 5.1)
+		// The level is the ffprobe-reported level in decimal (level * 30).
 		ret := "hvc1"
 
-		if stream.Profile == "main 10" {
+		if strings.Contains(strings.ToLower(stream.Profile), "10") {
+			// Main 10
 			ret += ".2.4"
 		} else {
-			ret += ".1.4"
+			// Main
+			ret += ".1.6"
 		}
 
-		ret += fmt.Sprintf(".L%02X.BO", stream.Level)
+		level := stream.Level
+		if level <= 0 {
+			level = 120 // assume level 4.0 when ffprobe doesn't report one
+		}
+
+		ret += fmt.Sprintf(".L%d.B0", level)
 		return &ret
 
 	case "av1":
@@ -420,9 +445,45 @@ func streamToMimeCodec(stream *ffprobe.Stream) *string {
 			bitdepth = 8
 		}
 
-		tierflag := 'M'
-		ret += fmt.Sprintf(".%02X%c.%02d", stream.Level, tierflag, bitdepth)
+		// The level is a decimal seq_level_idx (e.g. "08" for level 4.0), not hex
+		level := stream.Level
+		if level < 0 {
+			level = 8 // assume level 4.0 when ffprobe doesn't report one
+		}
 
+		tierflag := 'M'
+		ret += fmt.Sprintf(".%02d%c.%02d", level, tierflag, bitdepth)
+
+		return &ret
+
+	case "vp9":
+		// https://www.webmproject.org/vp9/mp4/
+		// FORMAT: vp09.[profile].[level].[bitDepth]
+		profile := "00"
+		switch strings.ToLower(stream.Profile) {
+		case "profile 1":
+			profile = "01"
+		case "profile 2":
+			profile = "02"
+		case "profile 3":
+			profile = "03"
+		}
+
+		level := stream.Level
+		if level <= 0 {
+			level = 10 // ffprobe often reports -99 for vp9, assume level 1.0
+		}
+
+		bitdepth, _ := strconv.ParseUint(stream.BitsPerRawSample, 10, 32)
+		if bitdepth != 10 && bitdepth != 12 {
+			bitdepth = 8
+		}
+
+		ret := fmt.Sprintf("vp09.%s.%02d.%02d", profile, level, bitdepth)
+		return &ret
+
+	case "vp8":
+		ret := "vp8"
 		return &ret
 
 	case "aac":
@@ -440,15 +501,26 @@ func streamToMimeCodec(stream *ffprobe.Stream) *string {
 		return &ret
 
 	case "opus":
-		ret := "Opus"
+		// Lowercase is required for the mp4 container ("audio/mp4; codecs=opus"),
+		// and browsers also accept it for webm/mkv.
+		ret := "opus"
+		return &ret
+
+	case "mp3":
+		ret := "mp4a.40.34"
+		return &ret
+
+	case "vorbis":
+		ret := "vorbis"
 		return &ret
 
 	case "ac3":
-		ret := "mp4a.a5"
+		// "ac-3" is the registered sample entry code (Safari/Edge); Chromium also accepts it
+		ret := "ac-3"
 		return &ret
 
 	case "eac3":
-		ret := "mp4a.a6"
+		ret := "ec-3"
 		return &ret
 
 	case "flac":

--- a/internal/mediastream/videofile/info_test.go
+++ b/internal/mediastream/videofile/info_test.go
@@ -5,7 +5,121 @@ import (
 	"path/filepath"
 	"seanime/internal/util"
 	"testing"
+
+	"gopkg.in/vansante/go-ffprobe.v2"
 )
+
+func TestStreamToMimeCodec(t *testing.T) {
+	tests := []struct {
+		name     string
+		stream   ffprobe.Stream
+		expected string // empty means nil expected
+	}{
+		{
+			name:     "h264 high level 4.0",
+			stream:   ffprobe.Stream{CodecName: "h264", Profile: "High", Level: 40},
+			expected: "avc1.640028",
+		},
+		{
+			name:     "hevc main level 4.0",
+			stream:   ffprobe.Stream{CodecName: "hevc", Profile: "Main", Level: 120},
+			expected: "hvc1.1.6.L120.B0",
+		},
+		{
+			name:     "hevc main 10 level 5.1",
+			stream:   ffprobe.Stream{CodecName: "hevc", Profile: "Main 10", Level: 153},
+			expected: "hvc1.2.4.L153.B0",
+		},
+		{
+			name:     "hevc unknown level",
+			stream:   ffprobe.Stream{CodecName: "hevc", Profile: "Main", Level: 0},
+			expected: "hvc1.1.6.L120.B0",
+		},
+		{
+			name:     "av1 main level 4.0 8bit",
+			stream:   ffprobe.Stream{CodecName: "av1", Profile: "Main", Level: 8, BitsPerRawSample: "8"},
+			expected: "av01.0.08M.08",
+		},
+		{
+			name:     "av1 main level 5.1 10bit",
+			stream:   ffprobe.Stream{CodecName: "av1", Profile: "Main", Level: 13, BitsPerRawSample: "10"},
+			expected: "av01.0.13M.10",
+		},
+		{
+			name:     "vp9 profile 0",
+			stream:   ffprobe.Stream{CodecName: "vp9", Profile: "Profile 0", Level: -99},
+			expected: "vp09.00.10.08",
+		},
+		{
+			name:     "vp9 profile 2 10bit",
+			stream:   ffprobe.Stream{CodecName: "vp9", Profile: "Profile 2", Level: 40, BitsPerRawSample: "10"},
+			expected: "vp09.02.40.10",
+		},
+		{
+			name:     "vp8",
+			stream:   ffprobe.Stream{CodecName: "vp8"},
+			expected: "vp8",
+		},
+		{
+			name:     "aac lc",
+			stream:   ffprobe.Stream{CodecName: "aac", Profile: "LC"},
+			expected: "mp4a.40.2",
+		},
+		{
+			name:     "opus",
+			stream:   ffprobe.Stream{CodecName: "opus"},
+			expected: "opus",
+		},
+		{
+			name:     "flac",
+			stream:   ffprobe.Stream{CodecName: "flac"},
+			expected: "fLaC",
+		},
+		{
+			name:     "ac3",
+			stream:   ffprobe.Stream{CodecName: "ac3"},
+			expected: "ac-3",
+		},
+		{
+			name:     "eac3",
+			stream:   ffprobe.Stream{CodecName: "eac3"},
+			expected: "ec-3",
+		},
+		{
+			name:     "mp3",
+			stream:   ffprobe.Stream{CodecName: "mp3"},
+			expected: "mp4a.40.34",
+		},
+		{
+			name:     "vorbis",
+			stream:   ffprobe.Stream{CodecName: "vorbis"},
+			expected: "vorbis",
+		},
+		{
+			name:     "unknown codec",
+			stream:   ffprobe.Stream{CodecName: "dts"},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := streamToMimeCodec(&tt.stream)
+			if tt.expected == "" {
+				if got != nil {
+					t.Fatalf("expected nil, got %q", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %q, got nil", tt.expected)
+			}
+			if *got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, *got)
+			}
+		})
+	}
+}
 
 func TestFfprobeGetInfo_1(t *testing.T) {
 	t.Skip()

--- a/seanime-web/src/app/(main)/_features/video-core/_lib/hooks.ts
+++ b/seanime-web/src/app/(main)/_features/video-core/_lib/hooks.ts
@@ -2,11 +2,24 @@ import { isMobile } from "@/lib/utils/browser-detection"
 
 export function useIsCodecSupported() {
     const isCodecSupported = (codec: string) => {
+        if (!codec) return false
         if (isMobile()) return false
-        if (navigator.userAgent.search("Firefox") === -1)
-            codec = codec.replace("video/x-matroska", "video/mp4")
+
         const videos = document.getElementsByTagName("video")
         const video = videos.item(0) ?? document.createElement("video")
+
+        if (codec.startsWith("video/x-matroska")) {
+            // Firefox cannot demux Matroska at all
+            if (navigator.userAgent.includes("Firefox")) return false
+            // Chromium-based browsers demux mkv through their mp4/webm pipelines,
+            // but report no support for "video/x-matroska" itself. Test the codec
+            // set against both containers: h264/hevc/av1 + aac/opus/flac resolve
+            // through mp4, while vp8/vp9 + vorbis resolve through webm.
+            const mp4 = codec.replace("video/x-matroska", "video/mp4")
+            const webm = codec.replace("video/x-matroska", "video/webm")
+            return video.canPlayType(mp4) === "probably" || video.canPlayType(webm) === "probably"
+        }
+
         return video.canPlayType(codec) === "probably"
     }
 


### PR DESCRIPTION
Closes #866

I wanted to watch more of my library in the browser without transcoding — right now only H.264+AAC files ever direct play. The reason is that the RFC 6381 codec strings generated from ffprobe data are malformed or missing for everything else, so the frontend's `canPlayType()` check always fails and playback falls back to the transcoder.

## Backend (`internal/mediastream/videofile/info.go`)

- Fix the HEVC codec string: `.L%02X.BO` printed the level in hex followed by a letter `O` typo (producing e.g. `hvc1.2.4.L78.BO`). Correct form is a decimal level plus the `B0` constraint byte (`hvc1.2.4.L120.B0`). Also fixed the Main profile compatibility flags (`.1.4` → `.1.6`) and defaulted to level 4.0 when ffprobe doesn't report one.
- Fix the AV1 level: seq_level_idx is decimal, not hex.
- Emit lowercase `opus` — `Opus` is rejected for the mp4 container, which is what the frontend tests against for mkv files. This alone was blocking direct play for a huge share of releases.
- Use the registered `ac-3` / `ec-3` sample entry codes for AC3/EAC3.
- Add missing mappings: vp9 (`vp09.PP.LL.DD`), vp8, mp3 (`mp4a.40.34`), vorbis.
- Fall back to known container mime types when the OS mime database is absent — minimal docker images have no `/etc/mime.types`, which left `mimeCodec` nil for mkv.
- Bump the media info cache bucket name so previously cached malformed strings aren't reused.
- Added unit tests for `streamToMimeCodec`.

## Frontend (`video-core/_lib/hooks.ts`)

- Test mkv codec sets against both the mp4 **and** webm container variants (vp9/vp8/vorbis only resolve through webm) on Chromium-based browsers. Firefox (no Matroska demuxing) and mobile keep falling back to transcode like before.

## Testing

- Unit tests cover the generated strings for h264/hevc/av1/vp9/vp8/aac/opus/flac/ac3/eac3/mp3/vorbis and the nil case for unsupported codecs.
- Verified on my self-hosted setup (linux/arm64): HEVC, Opus and FLAC files that previously always transcoded now direct play in Chrome/Edge; AC3/DTS audio correctly still falls back to transcoding; Firefox still transcodes mkv as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)