### PR TITLE
fix(web): don't serve mediastream media container requests from query cache

### DIFF
--- a/seanime-web/src/api/hooks/mediastream.hooks.ts
+++ b/seanime-web/src/api/hooks/mediastream.hooks.ts
@@ -40,6 +40,11 @@ export function useRequestMediastreamMediaContainer(variables: Partial<RequestMe
         queryKey: [API_ENDPOINTS.MEDIASTREAM.RequestMediastreamMediaContainer.key, variables?.path, variables?.streamType],
         data: variables as RequestMediastreamMediaContainer_Variables,
         enabled: !!variables.path && !!variables.streamType && enabled,
+        // This request registers the file as the current media on the server (side effect),
+        // so it must never be served from cache: a cached response mounts the player before
+        // the server knows about the file, and the subtitle/attachment endpoints fail with
+        // "no file has been loaded".
+        gcTime: 0,
     })
 }
 


### PR DESCRIPTION
Closes #868

`POST /api/v1/mediastream/request` isn't a pure read — it registers the file as the current media on the server, and the subtitle/attachment endpoints only work while a file is registered. Because `useRequestMediastreamMediaContainer` wraps it in a cached tanstack query, reopening a recently watched episode serves the container from cache: the player mounts right away and fetches subtitle tracks before the background refetch re-registers the file, so they fail with `no file has been loaded` (surfaced as a 500 toast for every track). The video recovers on its own because it keeps re-requesting; the subtitle fetch only happens once.

Setting `gcTime: 0` on that query drops the cached entry as soon as the page unmounts, so mounting the player always waits for a fresh server response. Refetches during playback (e.g. window refocus) are unaffected since data stays available while the page is mounted.

Verified on my self-hosted setup: reopening episodes no longer throws subtitle errors, tracks load every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)