### PR TITLE
Watch history fix

### DIFF
--- a/internal/debrid/torbox/torbox.go
+++ b/internal/debrid/torbox/torbox.go
@@ -384,7 +384,7 @@ func (t *TorBox) GetTorrentDownloadUrl(opts debrid.DownloadTorrentOptions) (down
 		return "", fmt.Errorf("torbox: Failed to get download URL: %w", debrid.ErrNotAuthenticated)
 	}
 
-	url := t.baseUrl + fmt.Sprintf("/torrents/requestdl?token=%s&torrent_id=%s&zip_link=true", apiKey, opts.ID)
+	url := t.baseUrl + fmt.Sprintf("/torrents/requestdl?token=%s&torrent_id=%s&zip_link=true&append_name=true", apiKey, opts.ID)
 	if opts.FileId != "" {
 		// Get the actual file ID
 		torrent, err := t.getTorrent(opts.ID)
@@ -401,7 +401,7 @@ func (t *TorBox) GetTorrentDownloadUrl(opts debrid.DownloadTorrentOptions) (down
 		if fId == "" {
 			return "", fmt.Errorf("torbox: Failed to get download URL, file not found")
 		}
-		url = t.baseUrl + fmt.Sprintf("/torrents/requestdl?token=%s&torrent_id=%s&file_id=%s", apiKey, opts.ID, fId)
+		url = t.baseUrl + fmt.Sprintf("/torrents/requestdl?token=%s&torrent_id=%s&file_id=%s&append_name=true", apiKey, opts.ID, fId)
 	}
 
 	resp, err := t.doQuery("GET", url, nil, "application/json")

--- a/internal/mediaplayers/iina/iina.go
+++ b/internal/mediaplayers/iina/iina.go
@@ -38,6 +38,7 @@ type (
 		cmd            *exec.Cmd
 		prevSocketName string
 		exitedCh       chan struct{}
+		isFileLoaded   bool
 	}
 
 	// Subscriber is a subscriber to the iina events.
@@ -171,7 +172,10 @@ func (i *Iina) OpenAndPlay(filePath string, args ...string) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
+	i.playbackMu.Lock()
 	i.Playback = &Playback{}
+	i.isFileLoaded = false
+	i.playbackMu.Unlock()
 
 	// If the player is already running, just load the new file
 	var err error
@@ -258,8 +262,42 @@ func (i *Iina) Resume() error {
 	return nil
 }
 
+// waitForFileLoad waits until the iina track has sent the "file-loaded" event.
+func (i *Iina) waitForFileLoad(timeoutDuration time.Duration) error {
+	timeout := time.Now().Add(timeoutDuration)
+	for {
+		if time.Now().After(timeout) {
+			return errors.New("timed out waiting for file to load")
+		}
+
+		i.playbackMu.RLock()
+		isLoaded := i.isFileLoaded
+		i.playbackMu.RUnlock()
+
+		i.mu.Lock()
+		connClosed := i.conn == nil || i.conn.IsClosed()
+		i.mu.Unlock()
+
+		if connClosed {
+			return errors.New("iina is not running")
+		}
+
+		if isLoaded {
+			return nil
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
 // SeekToSlow seeks to the given position in the file.
 func (i *Iina) SeekToSlow(position float64) error {
+	// Wait for file to load before seeking
+	err := i.waitForFileLoad(30 * time.Second)
+	if err != nil {
+		i.Logger.Warn().Err(err).Msg("file didn't load in time, attempting seek anyway")
+	}
+
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
@@ -267,16 +305,37 @@ func (i *Iina) SeekToSlow(position float64) error {
 		return errors.New("iina is not running")
 	}
 
-	_, err := i.conn.Call("set_property", "time-pos", position)
+	// pause the player
+	_, err = i.conn.Call("set_property", "pause", true)
 	if err != nil {
 		return err
 	}
+
+	// unpause the player
+	defer func() {
+		_, _ = i.conn.Call("set_property", "pause", false)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, err = i.conn.Call("set_property", "time-pos", position)
+	if err != nil {
+		return err
+	}
+
+	time.Sleep(100 * time.Millisecond)
 
 	return nil
 }
 
 // SeekTo seeks to the given position in the file.
 func (i *Iina) SeekTo(position float64) error {
+	// Wait for file to load before seeking
+	err := i.waitForFileLoad(30 * time.Second)
+	if err != nil {
+		i.Logger.Warn().Err(err).Msg("file didn't load in time, attempting seek anyway")
+	}
+
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
@@ -284,7 +343,7 @@ func (i *Iina) SeekTo(position float64) error {
 		return errors.New("iina is not running")
 	}
 
-	_, err := i.conn.Call("set_property", "time-pos", position)
+	_, err = i.conn.Call("set_property", "time-pos", position)
 	if err != nil {
 		return err
 	}
@@ -381,6 +440,16 @@ func (i *Iina) listenForEvents(ctx context.Context) {
 
 	// Listen for events
 	for event := range events {
+		switch event.Name {
+		case "start-file":
+			i.playbackMu.Lock()
+			i.isFileLoaded = false
+			i.playbackMu.Unlock()
+		case "file-loaded":
+			i.playbackMu.Lock()
+			i.isFileLoaded = true
+			i.playbackMu.Unlock()
+		}
 		if event.Data != nil {
 			i.Playback.IsRunning = true
 			switch event.ID {
@@ -582,6 +651,7 @@ func (i *Iina) createCmd(filePath string, args ...string) (*exec.Cmd, error) {
 func (i *Iina) resetPlaybackStatus() {
 	i.playbackMu.Lock()
 	i.Logger.Trace().Msg("iina: Resetting playback status")
+	i.isFileLoaded = false
 	i.Playback.Filename = ""
 	i.Playback.Filepath = ""
 	i.Playback.Paused = false

--- a/internal/mediaplayers/mpv/mpv.go
+++ b/internal/mediaplayers/mpv/mpv.go
@@ -46,6 +46,7 @@ type (
 		prevSocketName string
 		exitedCh       chan struct{}
 		playbackSwitch bool
+		isFileLoaded   bool
 		freshPosition  bool
 		freshDuration  bool
 		autoSocket     bool
@@ -265,6 +266,7 @@ func (m *Mpv) OpenAndPlay(filePath string, args ...string) error {
 	m.playbackMu.Lock()
 	m.Playback = &Playback{}
 	m.playbackSwitch = false
+	m.isFileLoaded = false
 	m.freshPosition = false
 	m.freshDuration = false
 	m.playbackMu.Unlock()
@@ -363,8 +365,42 @@ func (m *Mpv) Resume() error {
 	return nil
 }
 
+// waitForFileLoad waits until the MPV track has sent the "file-loaded" event.
+func (m *Mpv) waitForFileLoad(timeoutDuration time.Duration) error {
+	timeout := time.Now().Add(timeoutDuration)
+	for {
+		if time.Now().After(timeout) {
+			return errors.New("timed out waiting for file to load")
+		}
+
+		m.playbackMu.RLock()
+		isLoaded := m.isFileLoaded
+		m.playbackMu.RUnlock()
+
+		m.mu.Lock()
+		connClosed := m.conn == nil || m.conn.IsClosed()
+		m.mu.Unlock()
+
+		if connClosed {
+			return errors.New("mpv is not running")
+		}
+
+		if isLoaded {
+			return nil
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
 // SeekToSlow seeks to the given position in the file by first pausing the player and unpausing it after seeking.
 func (m *Mpv) SeekToSlow(position float64) error {
+	// Wait for file to load before seeking
+	err := m.waitForFileLoad(30 * time.Second)
+	if err != nil {
+		m.Logger.Warn().Err(err).Msg("file didn't load in time, attempting seek anyway")
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -373,10 +409,15 @@ func (m *Mpv) SeekToSlow(position float64) error {
 	}
 
 	// pause the player
-	_, err := m.conn.Call("set_property", "pause", true)
+	_, err = m.conn.Call("set_property", "pause", true)
 	if err != nil {
 		return err
 	}
+
+	// unpause the player
+	defer func() {
+		_, _ = m.conn.Call("set_property", "pause", false)
+	}()
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -387,17 +428,17 @@ func (m *Mpv) SeekToSlow(position float64) error {
 
 	time.Sleep(100 * time.Millisecond)
 
-	// unpause the player
-	_, err = m.conn.Call("set_property", "pause", false)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
 // SeekTo seeks to the given position in the file.
 func (m *Mpv) SeekTo(position float64) error {
+	// Wait for file to load before seeking
+	err := m.waitForFileLoad(30 * time.Second)
+	if err != nil {
+		m.Logger.Warn().Err(err).Msg("file didn't load in time, attempting seek anyway")
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -405,7 +446,7 @@ func (m *Mpv) SeekTo(position float64) error {
 		return errors.New("mpv is not running")
 	}
 
-	_, err := m.conn.Call("set_property", "time-pos", position)
+	_, err = m.conn.Call("set_property", "time-pos", position)
 	if err != nil {
 		return err
 	}
@@ -848,7 +889,11 @@ func (m *Mpv) applyPlaybackEvent(event *mpvipc.Event) {
 	}
 
 	switch event.Name {
-	case "start-file", "file-loaded":
+	case "start-file":
+		m.isFileLoaded = false
+		m.startPlaybackSwitchLocked()
+	case "file-loaded":
+		m.isFileLoaded = true
 		m.startPlaybackSwitchLocked()
 	}
 
@@ -899,6 +944,7 @@ func (m *Mpv) resetPlaybackStatus() {
 	m.playbackMu.Lock()
 	m.Logger.Trace().Msg("mpv: Resetting playback status")
 	m.playbackSwitch = false
+	m.isFileLoaded = false
 	m.freshPosition = false
 	m.freshDuration = false
 	m.Playback.Filename = ""


### PR DESCRIPTION
- `torbox.go`
  - Download URLs now contain the filename which fixes watch history matching for TorBox
- `mpv.go`
  - `SeekTo` and `SeekToSlow` now wait for the file-loaded event from mpv before seeking.
     Previously on slow sources or connections the file data was not loaded fast enough and playback always started at 00:00
  - `SeekToSlow` no longer leaves mpv permanently paused if the seeking fails
- `iina.go`
  - Applied the same fixes since iina runs on mpv.
    I also noticed that for iina the `SeekToSlow` and `SeekTo` functions were identical so I copied over the logic from `mpv.go`

> Unfortunately I didn't get to test any of these changes to iina since I don't own a mac :(